### PR TITLE
arch: Architectural improvements v1.10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to EvoClaw will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.11] - 2026-03-12
+
+### Architecture Improvements
+- 新增 `run_id` 關聯 ID 傳入 container input_data，提升多群組除錯能力（Issue #1, #8）
+- 修正 outer timeout 硬編碼 300s 改用 `config.CONTAINER_TIMEOUT`，確保設定一致性（Issue #2）
+- 修正 IPC 未知 type 靜默忽略，現在記錄 warning 日誌（Issue #3）
+- 新增 `GroupQueue.wait_for_active()` 和 `shutdown_sync()`，graceful shutdown 等待執行中的 container（Issue #4）
+- 新增訊息去重機制（`_is_duplicate_message` + LRU fingerprint set），防止 webhook 重試造成重複處理（Issue #7）
+- 修正 `ipc_watcher._resolve_container_path` 引用未定義 `logger`（應為 `log`）導致 NameError（Issue #10）
+- 將 `asyncio.get_event_loop().run_in_executor()` 替換為 `asyncio.to_thread()`，修正 Python 3.10+ DeprecationWarning（Issue #9）
+
 ## [1.10.10] - 2026-03-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 以 Python 打造的 AI 助理框架，支援 Gemini、OpenAI 相容 API 及 Claude。
 內建**進化引擎**，讓助手隨著使用自動學習與改進。
 
-**v1.10.10** — **穩定性修正**：JSON 輸出 2MB 上限防止 DoS、circuit breaker asyncio.Lock 競態條件修正、DB connection atexit 正確關閉、stderr readline 30s 超時、Secret key 啟動驗證、group folder 路徑穿越漏洞修正、孤立任務清理完整化。**v1.10.9** — **對話記憶改善**：移除 800 字截斷、Session 管理修正（newSessionId 改用 UUID）、歷史時間窗可設定（預設 4 小時）、歷史訊息上限提升至 50 則。**v1.10.8** — **動態容器工具熱插拔（Skills 2.0）**：DevEngine 生成的 Skill 現可新增 Python 工具至容器，不需重建 image。`data/dynamic_tools/` 掛載至 `/app/dynamic_tools:ro`，啟動時自動 import 並注冊至 Gemini / Claude / OpenAI 三大 provider；Skills manifest 新增 `container_tools:` 欄位。**v1.10.7** — 修復 Telegram 二進位檔案發送 `cp950` 編碼錯誤。
+**v1.10.11** — **架構改善**：新增 `run_id` 關聯 ID 串接 host/container 日誌、訊息去重防止 webhook 重試重複處理、graceful shutdown 等待 container 完成、修正 IPC 未知 type 靜默忽略、修正 `_resolve_container_path` NameError、`asyncio.to_thread` 取代 deprecated `get_event_loop()`。**v1.10.10** — **穩定性修正**：JSON 輸出 2MB 上限防止 DoS、circuit breaker asyncio.Lock 競態條件修正、DB connection atexit 正確關閉、stderr readline 30s 超時、Secret key 啟動驗證、group folder 路徑穿越漏洞修正、孤立任務清理完整化。**v1.10.9** — **對話記憶改善**：移除 800 字截斷、Session 管理修正（newSessionId 改用 UUID）、歷史時間窗可設定（預設 4 小時）、歷史訊息上限提升至 50 則。**v1.10.8** — **動態容器工具熱插拔（Skills 2.0）**：DevEngine 生成的 Skill 現可新增 Python 工具至容器，不需重建 image。`data/dynamic_tools/` 掛載至 `/app/dynamic_tools:ro`，啟動時自動 import 並注冊至 Gemini / Claude / OpenAI 三大 provider；Skills manifest 新增 `container_tools:` 欄位。**v1.10.7** — 修復 Telegram 二進位檔案發送 `cp950` 編碼錯誤。
 
 ---
 

--- a/host/container_runner.py
+++ b/host/container_runner.py
@@ -279,6 +279,7 @@ async def run_container_agent(
         "evolutionHints": evolution_hints,  # 演化引擎動態注入的行為指引
         "conversationHistory": conversation_history if conversation_history is not None else conv_history,  # 最近的對話歷史，提供記憶能力
         "scheduledTasks": scheduled_tasks,  # 此群組的排程任務清單，讓 agent 可以列出和取消
+        "runId": run_id,  # 關聯 ID：供 container 在 stderr 中記錄，與 host 日誌對齊
     }
     input_json = json.dumps(input_data, ensure_ascii=True)
     # 記錄 container 啟動時間，用於計算回應時間（適應度追蹤）
@@ -315,7 +316,7 @@ async def run_container_agent(
         config.CONTAINER_IMAGE,
     ]
 
-    log.info(f"Starting container {container_name} for group {folder}")
+    log.info(f"Starting container {container_name} for group {folder} (run_id={run_id})")
 
     input_bytes = input_json.encode("utf-8")
 

--- a/host/evolution/daemon.py
+++ b/host/evolution/daemon.py
@@ -73,8 +73,7 @@ async def _run_cycle() -> None:
     DB 查詢都是同步的（sqlite3），用 executor 避免阻塞 event loop。
     """
     log.info("Evolution cycle starting")
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, _sync_evolve)
+    await asyncio.to_thread(_sync_evolve)
     log.info("Evolution cycle complete")
 
 

--- a/host/group_queue.py
+++ b/host/group_queue.py
@@ -314,7 +314,39 @@ class GroupQueue:
                     name=f"group-msg-{next_jid}",
                 )
 
+    def shutdown_sync(self) -> None:
+        """Signal shutdown from a synchronous context (e.g. signal handler).
+        No new tasks will be accepted after this call.
+        """
+        self._shutting_down = True
+        log.info(f"GroupQueue: shutdown signalled (active containers: {self._active_count})")
+
     async def shutdown(self) -> None:
         """Signal shutdown — no new tasks will be started."""
         self._shutting_down = True
         log.info(f"GroupQueue shutting down (active containers: {self._active_count})")
+
+    async def wait_for_active(self, timeout: float = 30.0) -> None:
+        """Wait until all in-flight containers finish, or until timeout expires.
+
+        Should be called after shutdown() during graceful shutdown to avoid
+        aborting containers mid-response and leaving cursor/IPC state inconsistent.
+        """
+        if self._active_count == 0:
+            return
+        log.info(
+            "Waiting up to %.0fs for %d active container(s) to finish...",
+            timeout,
+            self._active_count,
+        )
+        deadline = asyncio.get_event_loop().time() + timeout
+        while self._active_count > 0:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                log.warning(
+                    "Graceful shutdown timeout: %d container(s) still active",
+                    self._active_count,
+                )
+                break
+            await asyncio.sleep(min(0.5, remaining))
+        log.info("GroupQueue: all containers finished (or timeout reached)")

--- a/host/ipc_watcher.py
+++ b/host/ipc_watcher.py
@@ -313,6 +313,16 @@ async def _handle_ipc(payload: dict, group_folder: str, is_main: bool, route_fn:
                 f"⚠️ 檔案無法傳送：找不到 {fname}\n路徑：{host_path}"
             ))
 
+    else:
+        # Unknown IPC message type — log a warning instead of silently ignoring.
+        # This aids debugging when a stale container image sends an unrecognised type.
+        log.warning(
+            "Unknown IPC message type %r from group %s — payload keys: %s",
+            msg_type,
+            group_folder,
+            list(payload.keys()),
+        )
+
 async def _run_dev_task(payload: dict, group_jid: str, route_fn) -> None:
     """
     在背景執行 DevEngine 7 階段開發流程。
@@ -387,9 +397,8 @@ async def _run_apply_skill(
             group = next((g for g in groups if g["folder"] == group_folder), None)
             jid = group["jid"] if group else ""
 
-            # skills_engine.apply_skill 是同步函式，用 executor 避免阻塞 event loop
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, apply_skill, skill_path)
+            # skills_engine.apply_skill 是同步函式，用 to_thread 避免阻塞 event loop
+            result = await asyncio.to_thread(apply_skill, skill_path)
 
             if result.success:
                 msg = f"✅ Skill applied: {result.skill} v{result.version}"
@@ -433,8 +442,7 @@ async def _run_uninstall_skill(
             group = next((g for g in groups if g["folder"] == group_folder), None)
             jid = group["jid"] if group else ""
 
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, uninstall_skill, skill_name)
+            result = await asyncio.to_thread(uninstall_skill, skill_name)
 
             if result.success:
                 msg = f"✅ Skill uninstalled: {result.skill}"
@@ -469,8 +477,7 @@ async def _run_list_skills(
     """
     try:
         get_applied_skills = _get_skills_engine().get_applied_skills
-        loop = asyncio.get_event_loop()
-        skills = await loop.run_in_executor(None, get_applied_skills)
+        skills = await asyncio.to_thread(get_applied_skills)
 
         skills_list = [
             {"name": s.name, "version": s.version, "applied_at": s.applied_at}
@@ -568,7 +575,7 @@ def _resolve_container_path(container_path: str, group_folder: str) -> str | Non
     Uses pathlib.Path throughout for correct Windows backslash handling.
     """
     if not group_folder:
-        logger.warning("_resolve_container_path: empty group_folder for path %r", container_path)
+        log.warning("_resolve_container_path: empty group_folder for path %r", container_path)
         return None
 
     import pathlib

--- a/host/main.py
+++ b/host/main.py
@@ -4,6 +4,8 @@ EvoClaw Host — Main Entry Point
 Orchestrates message polling, container execution, IPC, and scheduling.
 """
 import asyncio
+import collections
+import hashlib
 import logging
 import signal
 import time
@@ -54,6 +56,30 @@ _sender_allowlist: set[str] = set()
 
 # 全域的 GroupQueue 實例，負責控制每個群組的 container 並發數量
 _group_queue = GroupQueue()
+
+# ── Message deduplication fence ───────────────────────────────────────────────
+# Short-lived in-memory set of recently-seen message fingerprints.
+# Prevents duplicate processing caused by webhook retries or channel double-delivery.
+# Uses an OrderedDict as a bounded LRU cache: oldest entries are evicted when full.
+_DEDUP_MAX = 1000  # maximum entries before oldest is evicted
+_seen_msg_fingerprints: collections.OrderedDict = collections.OrderedDict()
+
+
+def _is_duplicate_message(jid: str, sender: str, content: str) -> bool:
+    """Return True if this (jid, sender, content) combination was seen recently.
+
+    A SHA-256 fingerprint of the three values is used as the key to bound memory
+    usage. If the dedup set is full, the oldest entry is evicted (LRU eviction).
+    """
+    raw = f"{jid}\x00{sender}\x00{content}"
+    fp = hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+    if fp in _seen_msg_fingerprints:
+        _seen_msg_fingerprints.move_to_end(fp)  # mark as recently used
+        return True
+    _seen_msg_fingerprints[fp] = True
+    if len(_seen_msg_fingerprints) > _DEDUP_MAX:
+        _seen_msg_fingerprints.popitem(last=False)  # evict oldest
+    return False
 
 
 def _load_state() -> None:
@@ -114,6 +140,11 @@ async def _on_message(jid: str, sender: str, sender_name: str, content: str,
     """
     if not is_sender_allowed(sender, _sender_allowlist):
         log.debug(f"Sender {sender} blocked by allowlist")
+        return
+
+    # 去重複檢查：防止頻道 webhook 重試造成相同訊息被處理兩次
+    if _is_duplicate_message(jid, sender, content):
+        log.debug("Duplicate message fingerprint detected from %s in %s — skipping", sender, jid)
         return
 
     # 免疫系統檢查：偵測 prompt injection 攻擊或垃圾訊息
@@ -241,7 +272,7 @@ async def _process_group_messages(group: dict, messages: list[dict],
                 session_id=session_id,
                 on_success=_on_success_tracked,
             ),
-            timeout=300.0,  # 5-minute timeout per container run
+            timeout=config.CONTAINER_TIMEOUT,  # use central config value
         )
         # run_container_agent returns {"status": "error", ...} when no output markers found
         if not _run_succeeded and isinstance(result, dict) and result.get("status") == "error":
@@ -250,8 +281,8 @@ async def _process_group_messages(group: dict, messages: list[dict],
                 _group_fail_timestamps[jid] = time.time()
     except asyncio.TimeoutError:
         log.error(
-            "Container run timed out after 300s for group %s — message NOT dropped, "
-            "will be retried on next poll cycle", jid
+            "Container run timed out after %ds for group %s — message NOT dropped, "
+            "will be retried on next poll cycle", int(config.CONTAINER_TIMEOUT), jid
         )
         async with _group_fail_lock:
             _group_fail_counts[jid] = _group_fail_counts.get(jid, 0) + 1
@@ -465,6 +496,7 @@ async def main() -> None:
         global _running
         log.info(f"Received {sig}, shutting down...")
         _running = False
+        _group_queue.shutdown_sync()  # signal: no new tasks accepted
         if _stop_event is not None:
             _stop_event.set()  # Wake up all waiting coroutines immediately
 
@@ -487,6 +519,8 @@ async def main() -> None:
             _orphan_cleanup_loop(_stop_event),
         )
     finally:
+        # 等待所有進行中的 container 完成（最多 30 秒），避免截斷回覆或損毀 IPC 狀態
+        await _group_queue.wait_for_active(timeout=30.0)
         # 確保所有頻道在離開時都乾淨地斷線
         for channel in _loaded_channels:
             try:


### PR DESCRIPTION
## Summary

Architectural improvements addressing multiple issues found in v1.10.11 code review.

- Added `run_id` correlation ID to container `input_data` and host log lines, making it possible to trace a single run across host and container logs
- Fixed outer container timeout from hardcoded `300.0s` to `config.CONTAINER_TIMEOUT` so the value stays consistent with the central config
- IPC handler now logs a `WARNING` for unknown message types instead of silently ignoring them (aids debugging stale container images)
- Added `GroupQueue.shutdown_sync()` and `wait_for_active()` so graceful shutdown waits up to 30s for in-flight containers to complete before disconnecting channels
- Added `_is_duplicate_message()` LRU fingerprint fence in `_on_message` to prevent webhook retries from causing duplicate AI replies
- Fixed `NameError: name 'logger' is not defined` in `ipc_watcher._resolve_container_path` (module uses `log`, not `logger`)
- Replaced deprecated `asyncio.get_event_loop().run_in_executor()` with `asyncio.to_thread()` in ipc_watcher and evolution daemon (Python 3.10+ compatibility)

## Issues Fixed

Closes #1, #2, #3, #4, #7, #8, #9, #10

## Test plan

- [ ] Start host with multiple groups and verify `run_id=` appears in container startup log
- [ ] Send SIGTERM and verify log shows "Waiting up to 30s for N active container(s)" message
- [ ] Simulate a webhook retry (send same message twice quickly) and verify only one AI reply is sent
- [ ] Trigger a `send_file` IPC with empty `group_folder` and verify warning log instead of NameError
- [ ] Verify no DeprecationWarning in Python 3.10+ logs for event_loop calls

🤖 Generated with Claude Code
