### PR TITLE
ci: guard against env drift in host config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ ENABLED_CHANNELS=telegram
 
 # Telegram
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
-# TELEGRAM_UPLOAD_TIMEOUT=300  # seconds, default 300
+TELEGRAM_UPLOAD_TIMEOUT=300
 
 # WhatsApp (Meta Cloud API)
 # ENABLED_CHANNELS=telegram,whatsapp
@@ -64,12 +64,13 @@ GMAIL_POLL_INTERVAL=30
 
 # Timezone
 TZ=Asia/Taipei
+TIMEZONE=Asia/Taipei
 
 # Log level (DEBUG, INFO, WARNING, ERROR)
 LOG_LEVEL=INFO
 
 # Log format: "text" (human-readable, default) or "json" (structured, for Loki/Datadog/CloudWatch)
-# LOG_FORMAT=json
+LOG_FORMAT=text
 
 # Container settings
 CONTAINER_IMAGE=evoclaw-agent:latest
@@ -92,18 +93,23 @@ IPC_POLL_INTERVAL=1000
 # RATE_LIMIT_WINDOW_SECS=60
 
 # Dashboard (web UI at http://DASHBOARD_HOST:DASHBOARD_PORT)
-# DASHBOARD_HOST=127.0.0.1
+DASHBOARD_HOST=127.0.0.1
 # DASHBOARD_PORT=8765
-# DASHBOARD_USER=admin
-# DASHBOARD_PASSWORD=       # Set a non-empty password to enable HTTP Basic Auth
+DASHBOARD_USER=admin
+DASHBOARD_PASSWORD=change_me
 
 # Web Portal (browser chat UI at http://WEBPORTAL_HOST:WEBPORTAL_PORT)
-# WEBPORTAL_ENABLED=false
-# WEBPORTAL_HOST=127.0.0.1
+WEBPORTAL_ENABLED=false
+WEBPORTAL_HOST=127.0.0.1
 # WEBPORTAL_PORT=8766
 
 # Health check endpoint (used by load balancers / Docker HEALTHCHECK)
 # HEALTH_PORT=8767
+
+# Data directories (optional overrides)
+LOCALAPPDATA=
+DATA_DIR=./data
+STORE_DIR=./store
 
 # ── GitHub (optional) ─────────────────────────────────────────────────────────
 # Required for agent to use git push / gh repo create / gh pr create inside containers.

--- a/.github/workflows/envdrift.yml
+++ b/.github/workflows/envdrift.yml
@@ -1,0 +1,20 @@
+name: Env Drift
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  envdrift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Check .env.example drift (host)
+        run: npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include host


### PR DESCRIPTION
## Summary
This PR adds an automated env drift check and updates `.env.example` so key runtime env vars are declared in parseable form.

## Why
Issue #72 identified env documentation drift in `.env.example` (including security-relevant settings). Drift tends to reappear as config evolves.

## Changes
- Add `.github/workflows/envdrift.yml`
  - `npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include host`
- Add/normalize declared env keys in `.env.example`:
  - `TELEGRAM_UPLOAD_TIMEOUT`
  - `TIMEZONE`
  - `LOG_FORMAT`
  - `DASHBOARD_HOST`, `DASHBOARD_USER`, `DASHBOARD_PASSWORD`
  - `WEBPORTAL_ENABLED`, `WEBPORTAL_HOST`
  - `LOCALAPPDATA`, `DATA_DIR`, `STORE_DIR`

## Result
CI now guards against future cases where host-side env keys are used in code but missing from `.env.example`.
