### PR TITLE
fix(paths): replace stale data/ DB references with STORE_DIR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,7 +152,7 @@ STORE_DIR=./store
 #   pip install psycopg2-binary
 #   createdb evoclaw
 # DATABASE_URL=postgresql://user:password@localhost:5432/evoclaw
-# DB_PATH=data/messages.db  # SQLite path (default, only used when DATABASE_URL is unset)
+# DB_PATH=/absolute/path/to/messages.db  # Override SQLite path (defaults to $STORE_DIR/messages.db; only used when DATABASE_URL is unset)
 
 # ── GitHub (optional) ─────────────────────────────────────────────────────────
 # Required for agent to use git push / gh repo create / gh pr create inside containers.

--- a/Makefile
+++ b/Makefile
@@ -44,5 +44,5 @@ clean: ## Remove generated files (data, ipc, __pycache__)
 		echo "Cancelled"; \
 	fi
 
-db: ## Open SQLite shell on the database
-	sqlite3 data/evoclaw.db
+db: ## Open SQLite shell on the EvoClaw subsystem database (evoclaw.db)
+	@python -c "from host import config; import subprocess; subprocess.run(['sqlite3', str(config.STORE_DIR / 'evoclaw.db')])"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.26.2] — 2026-04-09
+
+### Fixed
+- **Stale `data/` DB path references in three places** — `Makefile:48`, `host/db_adapter.py:27`, and `host/migrations/sqlite_to_pg.py:51` all defaulted to `data/evoclaw.db` / `data/messages.db`, a layout the live host code has not used since `STORE_DIR` was introduced. `make db` was broken for everyone on default paths, and the offline adapter/migrator tools only worked if the caller remembered to set `DB_PATH`/`SQLITE_PATH` by hand. All three now resolve `config.STORE_DIR` so they point at the same DB the running host uses (`%LOCALAPPDATA%\evoclaw\store\` on Windows, `./store/` elsewhere). (#519)
+
+### Technical Details
+- **Modified Files**: `Makefile`, `host/db_adapter.py`, `host/migrations/sqlite_to_pg.py`, `.env.example`
+- **Makefile**: `db` target now shells out through a small Python one-liner so that `STORE_DIR` is resolved identically to the host process (handling the Windows `%LOCALAPPDATA%` default).
+- **db_adapter.py / sqlite_to_pg.py**: Added `from host import config` at module level; both default `DB_PATH` / `SQLITE_PATH` now come from `config.STORE_DIR / "messages.db"`. Explicit env overrides still win.
+- **.env.example**: Stale comment updated to describe the new default resolution.
+- **Breaking Changes**: None. Anyone relying on the old default by pre-seeding a `data/` directory must now either set `DB_PATH` explicitly or move the file into `STORE_DIR`.
+
 ## [1.26.1] — 2026-04-09
 
 ### Fixed

--- a/host/db_adapter.py
+++ b/host/db_adapter.py
@@ -12,6 +12,8 @@ import os
 import logging
 from typing import Any
 
+from host import config
+
 log = logging.getLogger(__name__)
 
 _DATABASE_URL = os.environ.get("DATABASE_URL", "")
@@ -24,7 +26,7 @@ class _SqliteAdapter:
 
     def connect(self):
         import sqlite3
-        db_path = os.environ.get("DB_PATH", "data/messages.db")
+        db_path = os.environ.get("DB_PATH") or str(config.STORE_DIR / "messages.db")
         conn = sqlite3.connect(db_path, check_same_thread=False)
         conn.row_factory = sqlite3.Row
         # Mirror the pragmas used by init_database() in db.py so that any

--- a/host/migrations/sqlite_to_pg.py
+++ b/host/migrations/sqlite_to_pg.py
@@ -1,13 +1,18 @@
 """Migrate data from SQLite to PostgreSQL.
 
 Usage:
-    DATABASE_URL=postgresql://... SQLITE_PATH=data/messages.db python -m host.migrations.sqlite_to_pg
+    DATABASE_URL=postgresql://... python -m host.migrations.sqlite_to_pg
+
+SQLITE_PATH defaults to ``config.STORE_DIR / "messages.db"`` (the same path the
+live host process uses). Override by setting ``SQLITE_PATH`` explicitly.
 """
 import os
 import re
 import sqlite3
 import sys
 import logging
+
+from host import config
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +53,7 @@ def _safe_identifier(name: str) -> str:
 
 
 def migrate():
-    sqlite_path = os.environ.get("SQLITE_PATH", "data/messages.db")
+    sqlite_path = os.environ.get("SQLITE_PATH") or str(config.STORE_DIR / "messages.db")
     pg_url = os.environ.get("DATABASE_URL", "")
 
     if not pg_url:


### PR DESCRIPTION
## Summary
Three long-stale spots still defaulted DB paths to `data/`, a layout the live host process has not used since `STORE_DIR` landed. All three now resolve through `config.STORE_DIR`, so they point at the same DB the running host uses (`%LOCALAPPDATA%\evoclaw\store\` on Windows, `./store/` elsewhere).

## Changes
- **`Makefile:48`** — `make db` now shells out to a small Python one-liner that resolves `config.STORE_DIR / "evoclaw.db"` before invoking `sqlite3`. Handles the Windows `%LOCALAPPDATA%` default the same way the host does.
- **`host/db_adapter.py`** — Added `from host import config`; `DB_PATH` default is now `config.STORE_DIR / "messages.db"`. Explicit `DB_PATH` overrides still win, so existing `tests/test_db_adapter.py` tests (which pin the env var) pass unchanged.
- **`host/migrations/sqlite_to_pg.py`** — Same treatment for `SQLITE_PATH`; docstring example also updated so we stop leaking the stale path back to users.
- **`.env.example`** — Comment referencing `DB_PATH=data/messages.db` updated to describe the new default resolution.
- **`docs/CHANGELOG.md`** — Added a `1.26.2` entry.

## Why this matters
`db_adapter.py` and `sqlite_to_pg.py` are offline tools the main host doesn't import, so the bad defaults only bit users who ran them without setting the env var. `make db` was worse — it failed for **everyone** on default paths. Background + discovery context is in #519.

## Test plan
- [x] `python -m pytest tests/test_db_adapter.py -x` — 7/7 pass (existing tests pin `DB_PATH`, so they verify override still wins).
- [ ] Manual: `make db` opens a sqlite shell on the real `STORE_DIR / "evoclaw.db"` (verified on Windows that the command resolves to `C:\Users\<user>\AppData\Local\evoclaw\store\evoclaw.db`).

Closes #519
