### PR TITLE
chore(meta): formalize issue → PR → merge → CHANGELOG workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,31 @@
+## Linked Issue
+
+<!--
+Every PR should reference a tracking issue. Use one of:
+  Closes #N      Fixes #N      Resolves #N      Refs #N
+If there is genuinely no issue (e.g. a tiny typo fix), add the `no-issue`
+label to this PR to bypass the CI check.
+-->
+
+Closes #
+
 ## Type of Change
 
-- [ ] **Skill** - adds a new skill in `.claude/skills/`
-- [ ] **Fix** - bug fix or security fix to source code
-- [ ] **Simplification** - reduces or simplifies source code
+- [ ] **Fix** — bug fix or security fix to source code
+- [ ] **Simplification** — reduces or simplifies source code
+- [ ] **Skill** — adds a new skill in `.claude/skills/`
+- [ ] **Chore / meta** — tooling, CI, docs, or repo housekeeping
 
 ## Description
 
+<!-- What changed and why. Call out any migration steps or breaking changes. -->
+
+## Checklist
+
+- [ ] PR body links an issue (or I added the `no-issue` label)
+- [ ] `docs/CHANGELOG.md` has an entry for this change (or I added the `skip-changelog` label — only valid for non-runtime PRs)
+- [ ] `README.md` updated if user-visible behavior changed (install steps, env vars, commands, architecture)
+- [ ] Tests added or updated where relevant, and `pytest tests/` passes locally
 
 ## For Skills
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,64 @@
+name: PR checks
+
+# Lightweight PR metadata gate that enforces the issue → PR → merge → CHANGELOG
+# workflow documented in CONTRIBUTING.md. Intentionally plain bash + gh CLI so
+# no third-party actions need to be audited.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  linked-issue:
+    name: PR body links an issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require issue link in PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$PR_LABELS" | grep -q '"no-issue"'; then
+            echo "PR has 'no-issue' label — skipping issue link check."
+            exit 0
+          fi
+          if ! printf '%s' "$PR_BODY" | grep -Eqi '(closes|fixes|resolves|refs)[[:space:]]+#[0-9]+'; then
+            echo "::error::PR body must reference an issue with 'Closes #N', 'Fixes #N', 'Resolves #N', or 'Refs #N'. Add the 'no-issue' label if this PR genuinely has no tracking issue."
+            exit 1
+          fi
+          echo "PR body links to an issue."
+
+  changelog:
+    name: CHANGELOG updated for runtime changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require CHANGELOG update when runtime source changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$PR_LABELS" | grep -q '"skip-changelog"'; then
+            echo "PR has 'skip-changelog' label — skipping CHANGELOG check."
+            exit 0
+          fi
+          CHANGED=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
+          echo "Files changed in this PR:"
+          printf '%s\n' "$CHANGED"
+          if ! printf '%s\n' "$CHANGED" | grep -Eq '^(host/|container/|scripts/|Makefile|\.env\.example)'; then
+            echo "No runtime source paths touched — CHANGELOG update not required."
+            exit 0
+          fi
+          if ! printf '%s\n' "$CHANGED" | grep -q '^docs/CHANGELOG\.md$'; then
+            echo "::error::This PR modifies runtime source (host/, container/, scripts/, Makefile, or .env.example) but does not update docs/CHANGELOG.md. Add an entry to docs/CHANGELOG.md, or add the 'skip-changelog' label if this change legitimately does not warrant one."
+            exit 1
+          fi
+          echo "docs/CHANGELOG.md is updated."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,28 @@
 
 **Not accepted:** Features, capabilities, compatibility, enhancements. These should be skills.
 
+## How to propose changes
+
+All source changes flow through **issue → PR → merge → CHANGELOG → README**. CI enforces the issue-link and CHANGELOG parts; the README part is a human judgement call.
+
+1. **Open an issue first.** Use `gh issue create` (or the GitHub UI) with one of the templates in `.github/ISSUE_TEMPLATE/`. Describe the problem, not the fix. If an issue already exists, skip this step.
+2. **Branch from `main`.** Use a short descriptive prefix: `fix/<slug>`, `chore/<slug>`, `docs/<slug>`, `skill/<slug>`.
+3. **Implement + commit.** Small, focused commits are fine; they'll be squashed on merge. Conventional commit prefixes (`fix:`, `chore:`, `docs:`, `feat:`) are encouraged.
+4. **Update `docs/CHANGELOG.md`** in the *same* PR. Add a new `## [MAJOR.MINOR.PATCH] — YYYY-MM-DD` block at the top with `### Fixed` / `### Added` / `### Changed` entries that reference the issue/PR number. Patch bumps for fixes, minor for features, major for breaking changes.
+   - **Exception:** if the PR touches none of `host/`, `container/`, `scripts/`, `Makefile`, or `.env.example`, CI will not require a CHANGELOG entry. Add the `skip-changelog` label if you want to make the exemption explicit.
+5. **Update `README.md` only if user-visible behavior changed** — new env vars, new commands, new install steps, architectural shifts. Pure internal fixes don't need README changes. Keep `README_en.md` in sync if you do touch `README.md`.
+6. **Push the branch and open a PR.** The PR body **must** contain `Closes #N`, `Fixes #N`, `Resolves #N`, or `Refs #N`. The `.github/PULL_REQUEST_TEMPLATE.md` has the slot. If this PR genuinely has no tracking issue, add the `no-issue` label to bypass the CI gate.
+7. **Squash merge.** Use `gh pr merge <N> --squash --delete-branch`. The squashed commit message automatically gets `(#PR)` appended, which matches the existing history style.
+
+### Escape hatch labels
+
+| Label | Effect |
+|---|---|
+| `no-issue` | Skips the "PR body must link an issue" CI check |
+| `skip-changelog` | Skips the CHANGELOG update requirement (only valid for PRs that don't touch runtime source paths) |
+
+Use sparingly — they exist for legitimate exceptions (tiny typos, CI-only housekeeping), not for shortcutting the flow.
+
 ## Skills
 
 A [skill](https://code.claude.com/docs/en/skills) is a markdown file in `skills/` that teaches Claude Code how to transform a EvoClaw installation.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.27.0] — 2026-04-10
+
+### Added
+- **Formal contribution workflow + CI enforcement.** `CONTRIBUTING.md` now documents the `issue → PR → merge → CHANGELOG → README` flow end-to-end, the PR template gains a **Linked Issue** slot plus checklist items, and a new `.github/workflows/pr-checks.yml` gates PRs on two rules: (1) PR body must contain `Closes/Fixes/Resolves/Refs #N` (escape hatch: `no-issue` label); (2) if the PR touches `host/`, `container/`, `scripts/`, `Makefile`, or `.env.example`, then `docs/CHANGELOG.md` must also be modified (escape hatch: `skip-changelog` label). The workflow is pure bash + `gh` CLI — no third-party actions. (#522)
+
+### Technical Details
+- **New Files**: `.github/workflows/pr-checks.yml`
+- **Modified Files**: `.github/PULL_REQUEST_TEMPLATE.md`, `CONTRIBUTING.md`
+- **New Labels (must be created manually in the repo settings or first use)**: `no-issue`, `skip-changelog`
+- **Breaking Changes**: Open PRs that don't link an issue in the body will start failing CI after this merges. Fix by editing the PR body to include `Closes #N` (or add the `no-issue` label).
+
 ## [1.26.2] — 2026-04-09
 
 ### Fixed


### PR DESCRIPTION
## Linked Issue

Closes #522

## Type of Change

- [x] **Chore / meta** — tooling, CI, docs, or repo housekeeping

## Description

Writes down the `issue → PR → merge → CHANGELOG → README` convention we already follow culturally, and puts a lightweight CI gate behind it so it stops being cultural-only.

### What changes

- **`.github/PULL_REQUEST_TEMPLATE.md`** — adds a **Linked Issue** slot at the top, a `Chore / meta` type, and a per-PR checklist covering issue link, CHANGELOG, README, and tests. Keeps the existing Skill section intact.
- **`CONTRIBUTING.md`** — new **How to propose changes** section with the concrete 7-step flow and a documentation of the two escape-hatch labels.
- **`.github/workflows/pr-checks.yml` (new)** — pure bash + `gh` CLI, two jobs:
  1. **`linked-issue`** — PR body must contain `Closes/Fixes/Resolves/Refs #N`. Escape hatch: `no-issue` label.
  2. **`changelog`** — if any changed file matches `^(host/|container/|scripts/|Makefile|\.env\.example)`, then `docs/CHANGELOG.md` must also be modified. Escape hatch: `skip-changelog` label.
- **`docs/CHANGELOG.md`** — `[1.27.0] — 2026-04-10` entry.

### Scope decisions (YAGNI)

- **No third-party actions.** Pure bash + `gh` CLI so there's nothing external to audit.
- **CHANGELOG gate is conditional**, not universal — docs/CI/typo PRs legitimately don't warrant a changelog entry, so the check is scoped to runtime source paths.
- **No semver/release automation** — the existing `bump-version.yml` bumps `package.json` patch on src changes and will keep doing its thing. This PR doesn't touch it.
- **No commit-message linting** — different concern, save for another issue if needed.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-checks.yml', encoding='utf-8'))"` parses cleanly; both jobs (`linked-issue`, `changelog`) are discovered.
- [x] This PR itself complies: body contains `Closes #522`, and no runtime source paths are touched, so the `changelog` gate is satisfied even though we *did* update `docs/CHANGELOG.md` voluntarily.
- [ ] Post-merge: create the two labels via `gh label create no-issue --description "Skip 'PR body must link an issue' gate" --color BFD4F2` and `gh label create skip-changelog --description "Skip 'CHANGELOG must be updated' gate" --color BFD4F2` the first time they're needed.

## Breaking changes

Open PRs that don't link an issue in the body will start failing CI after merge. Fix by editing the PR body to add `Closes #N`, or by applying the `no-issue` label.
