### PR TITLE
fix(container): tool_grep streams stdout with 8 KB hard cap (#526)

### DIFF
--- a/container/agent-runner/_tools.py
+++ b/container/agent-runner/_tools.py
@@ -902,22 +902,81 @@ def tool_grep(pattern: str, path: str = WORKSPACE, include: str = "*") -> str:
     # Validate include is a plain glob pattern (no path separators)
     if "/" in include or "\\" in include or ".." in include:
         return "Error: include parameter must be a plain filename glob (e.g. '*.py'), not a path"
+    # Issue #526 (L1 OOM fix): stream grep stdout in small chunks and kill the
+    # grep process the moment we have 8 KB of output.  The previous version used
+    # subprocess.run(capture_output=True), which reads the *entire* stdout into
+    # a Python str before truncating — a wide pattern on a repo-mounted
+    # workspace could produce hundreds of MB of matches and OOM the container
+    # (exit 137) before the truncation line was ever executed.  With Popen +
+    # bounded read() + proc.kill() the hard cap is enforced at the kernel pipe
+    # level, so the caller never allocates more than ~8 KB for grep output.
+    import threading as _threading
+    _GREP_MAX_BYTES = 8192
+    _GREP_TIMEOUT = 30.0
+    proc = None
+    watchdog = None
     try:
-        result = subprocess.run(
+        proc = subprocess.Popen(
             ["grep", "-r", "-n", "--include", include, pattern, path],
-            capture_output=True, text=True, timeout=30,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
         )
-        output = result.stdout
-        if result.stderr and not output:
-            output = result.stderr
-        if len(output) > 8000:
-            output = output[:8000] + "\n... (truncated, too many matches)"
+        # Hard timeout watchdog: Popen has no built-in timeout= for chunked reads.
+        watchdog = _threading.Timer(_GREP_TIMEOUT, proc.kill)
+        watchdog.daemon = True
+        watchdog.start()
+
+        buf = bytearray()
+        truncated = False
+        while True:
+            chunk = proc.stdout.read(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+            if len(buf) >= _GREP_MAX_BYTES:
+                truncated = True
+                proc.kill()  # stop grep scanning the filesystem immediately
+                break
+
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
+
+        # Only drain stderr if stdout was empty (diagnostic / no-match path).
+        if not buf:
+            try:
+                err = proc.stderr.read(2048) or b""
+            except Exception:
+                err = b""
+            if err:
+                buf.extend(err)
+
+        # Detect timeout: watchdog fired and killed the process before EOF.
+        # grep exit status: 0=matches found, 1=no matches, 2+=error, -9/SIGKILL=killed.
+        _killed_by_watchdog = (proc.returncode is not None and proc.returncode < 0 and not truncated and not buf)
+        if _killed_by_watchdog:
+            return f"Error: grep timed out after {int(_GREP_TIMEOUT)}s"
+
+        output = bytes(buf[:_GREP_MAX_BYTES]).decode("utf-8", errors="replace")
+        if truncated:
+            output += "\n... (truncated at 8 KB — refine pattern or narrow include)"
         return output or "(no matches found)"
-    except subprocess.TimeoutExpired:
-        return "Error: grep timed out after 30s"
     except Exception as e:
         return f"Error: {e}"
+    finally:
+        if watchdog is not None:
+            watchdog.cancel()
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.kill()
+                proc.wait(timeout=2)
+            except Exception:
+                pass
 
 
 def tool_web_fetch(url: str) -> str:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.27.1] — 2026-04-10
+
+### Fixed
+- **`tool_grep` OOM via unbounded stdout read.** `container/agent-runner/_tools.py` previously used `subprocess.run(capture_output=True)` and only truncated the grep output **after** the full stdout had been read into a Python string. A wide pattern against a repo-mounted workspace could produce hundreds of MB of matches and OOM the container (exit 137) before the 8 KB truncation line was ever reached — the 8 KB cap was an illusion. Rewrote `tool_grep` using `Popen` + chunked `read(4096)` that kills the grep process the moment the 8 KB byte budget is hit, so the hard cap is enforced at the kernel pipe level. A `threading.Timer` watchdog replaces the previous `run(timeout=30)` behavior. (#526)
+
+### Technical Details
+- **Modified Files**: `container/agent-runner/_tools.py`
+- **New Files**: `tests/test_tool_grep_streaming.py` — regression test seeding ~200 KB of matching lines and asserting `tool_grep` returns < 9 KB, plus a Popen spy verifying `proc.kill()` is invoked when the budget is reached.
+- **Breaking Changes**: None. Callers of `tool_grep` still see at most 8 KB plus a truncation marker; the marker text changed from `... (truncated, too many matches)` to `... (truncated at 8 KB — refine pattern or narrow include)` to hint at the actual constraint.
+
 ## [1.27.0] — 2026-04-10
 
 ### Added

--- a/tests/test_tool_grep_streaming.py
+++ b/tests/test_tool_grep_streaming.py
@@ -1,0 +1,147 @@
+"""
+Test for Issue #526 (L1 OOM fix): tool_grep must stream-cap its output and
+kill the grep subprocess the moment the 8 KB budget is reached, instead of
+reading the entire grep stdout into memory and truncating after the fact.
+
+Regression test: previously tool_grep used subprocess.run(capture_output=True)
+which reads the full stdout into a Python str before applying the 8000-char
+cap.  A wide pattern against a repo-mounted workspace could produce hundreds
+of MB of matches and OOM the container (exit 137) before the truncation line
+was ever executed.  The fix switches to Popen + chunked read() + proc.kill().
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add container/agent-runner/ to sys.path so we can import _tools directly.
+_AGENT_DIR = Path(__file__).parent.parent / "container" / "agent-runner"
+if str(_AGENT_DIR) not in sys.path:
+    sys.path.insert(0, str(_AGENT_DIR))
+
+
+def _import_tools():
+    import importlib
+    if "_tools" in sys.modules:
+        return importlib.reload(sys.modules["_tools"])
+    return importlib.import_module("_tools")
+
+
+@pytest.fixture
+def tools():
+    return _import_tools()
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """Stage a temp workspace and teach _tools that it is allowed.
+
+    Both the `_check_path_allowed` helper (imported by name from _utils into
+    _tools) and the `_ALLOWED_PATH_PREFIXES` tuple (imported by name from
+    _constants into _tools) are rebound on the _tools module so the path
+    sandbox accepts the pytest tmp_path.  On Windows pytest's tmp_path is
+    under C:\\Users\\...\\Temp\\pytest-of-*, nowhere near /workspace/, so the
+    production allowlist would otherwise reject every test case.
+    """
+    _tools = _import_tools()
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    resolved = str(ws.resolve())
+    monkeypatch.setattr(_tools, "WORKSPACE", resolved)
+    monkeypatch.setattr(_tools, "_ALLOWED_PATH_PREFIXES", (resolved,))
+    monkeypatch.setattr(_tools, "_check_path_allowed", lambda p: None)
+    return ws
+
+
+def test_grep_small_output_returned_verbatim(tools, workspace):
+    """Happy path: few matches, output well under the 8 KB cap."""
+    (workspace / "a.txt").write_text("hello world\nanother line\n")
+    (workspace / "b.txt").write_text("no match here\n")
+    out = tools.tool_grep("hello", str(workspace), "*.txt")
+    assert "hello world" in out
+    assert "truncated" not in out
+
+
+def test_grep_no_match_returns_sentinel(tools, workspace):
+    (workspace / "a.txt").write_text("nothing to see here\n")
+    out = tools.tool_grep("zzz_no_such_string", str(workspace), "*.txt")
+    assert out == "(no matches found)"
+
+
+def test_grep_output_capped_at_8kb(tools, workspace):
+    """
+    Seed a file with ~200 KB of matching lines.  The fix must cap the
+    returned string at ~8 KB (+ truncation marker), not balloon to 200 KB.
+    This is the core regression check for Issue #526.
+    """
+    big = workspace / "big.txt"
+    # ~200 KB of grep matches (each line is ~40 bytes, 5000 lines).
+    big.write_text("matchme_" + "x" * 30 + "\n" * 1)  # dummy init write
+    with big.open("w") as f:
+        for i in range(5000):
+            f.write(f"matchme line {i} " + "x" * 20 + "\n")
+
+    out = tools.tool_grep("matchme", str(workspace), "*.txt")
+
+    # Core assertion: output is bounded, NOT the full 200 KB.
+    assert len(out) < 9000, (
+        f"tool_grep returned {len(out)} bytes — streaming cap failed"
+    )
+    # Truncation marker must be present since we exceeded 8 KB.
+    assert "truncated" in out
+    # Sanity: some actual grep content is in the first chunk.
+    assert "matchme" in out
+
+
+def test_grep_kills_subprocess_early(tools, workspace, monkeypatch):
+    """
+    Verify that when the byte budget is reached, tool_grep calls proc.kill()
+    rather than draining the full stdout pipe.  This is what prevents OOM
+    on a repo-scale match.
+    """
+    killed = {"called": False}
+
+    real_popen = subprocess.Popen
+
+    class SpyProc:
+        def __init__(self, *a, **kw):
+            # Spawn a real grep on a large file so stdout actually streams.
+            self._p = real_popen(*a, **kw)
+            self.stdout = self._p.stdout
+            self.stderr = self._p.stderr
+
+        def kill(self):
+            killed["called"] = True
+            return self._p.kill()
+
+        def wait(self, *a, **kw):
+            return self._p.wait(*a, **kw)
+
+        def poll(self):
+            return self._p.poll()
+
+        @property
+        def returncode(self):
+            return self._p.returncode
+
+    # Build a file that will blow past 8 KB of matches.
+    big = workspace / "big.txt"
+    with big.open("w") as f:
+        for i in range(5000):
+            f.write(f"matchme row {i} " + "y" * 40 + "\n")
+
+    with patch.object(subprocess, "Popen", SpyProc):
+        out = tools.tool_grep("matchme", str(workspace), "*.txt")
+
+    assert killed["called"], "proc.kill() was not invoked after byte budget"
+    assert "truncated" in out
+    assert len(out) < 9000
+
+
+def test_grep_rejects_path_escape(tools):
+    """Use the real (unmocked) path sandbox — do not depend on fixture."""
+    out = tools.tool_grep("anything", "/etc", "*")
+    assert "access denied" in out or "outside" in out or "Only paths" in out


### PR DESCRIPTION
Closes #526

## Summary

`tool_grep` previously used `subprocess.run(capture_output=True)` and truncated the output to 8 000 chars **after** Python had already read the entire grep stdout into a str. A wide pattern against a repo-mounted workspace could produce hundreds of MB of matches and OOM the container (exit 137) before the truncation line was ever reached. The 8 KB cap was an illusion from the caller's perspective.

This PR rewrites `tool_grep` in `container/agent-runner/_tools.py` to use `Popen` + chunked `read(4096)` that calls `proc.kill()` the moment the 8 KB byte budget is reached, so the cap is enforced at the kernel pipe level. A `threading.Timer` watchdog replaces the previous `run(timeout=30)` behavior.

## Why this matters

This is the root cause of a 2026-04-09 container OOM in a Level-A openai-compat session. Once this lands, follow-up PR (Issue A) will lower `CONTAINER_MEMORY` default from `2g` → `512m` — analysis showed the steady-state agent process RSS is 80-150 MB and the 2 GB default was only masking this one bug.

## Changes

- `container/agent-runner/_tools.py` — rewrite `tool_grep` subprocess block (Popen + streaming + early kill)
- `tests/test_tool_grep_streaming.py` — new regression test:
  - seeds ~200 KB of matching lines and asserts `tool_grep` returns < 9 KB
  - uses a `Popen` spy to verify `proc.kill()` is invoked when the budget is reached
  - happy-path + no-match + path-escape coverage
- `docs/CHANGELOG.md` — `[1.27.1]` entry under `### Fixed`

## Test plan

- [x] `python -m pytest tests/test_tool_grep_streaming.py -q` → 5 passed
- [ ] Post-merge smoke test: run a real agent session with a wide Grep call against a main-group container and verify exit 0 + bounded RSS
- [ ] Existing test suite still green

## Backwards compatibility

- Caller-visible return value is still ≤ 8 KB + optional truncation marker
- Truncation marker text changed from `... (truncated, too many matches)` to `... (truncated at 8 KB — refine pattern or narrow include)` to hint at the actual constraint
- No other callers or tools touched
