### PR TITLE
chore(container): lower CONTAINER_MEMORY default 2g → 512m (#528)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.27.2] — 2026-04-10
+
+### Changed
+- **Lowered `CONTAINER_MEMORY` default from `2g` to `512m`.** Post-#527 analysis showed steady-state agent-process RSS is 80-150 MB (Python + one lazy-loaded LLM SDK + stdlib; no eager pandas/numpy/matplotlib imports). The 2 GB default was masking a single `tool_grep` bug (fixed in #527) and was never calibrated to real footprint. 512 MB leaves ~3× headroom over steady state while cutting the worst-case aggregate (with `MAX_CONCURRENT_CONTAINERS=5`) from 10 GB to 2.5 GB — comfortable on hosts with ≤16 GB RAM. (#528)
+
+### Technical Details
+- **Modified Files**: `host/config.py`
+- **Breaking Changes**: Users running very long-context openai/claude sessions may want to override `CONTAINER_MEMORY=768m` in `.env`. Do NOT revert to `2g` — the comment in `config.py` now documents the full history.
+- **Depends on**: #527 (tool_grep streaming fix). Without it, 512 MB is unsafe under wide-grep workloads.
+
 ## [1.27.1] — 2026-04-10
 
 ### Fixed

--- a/host/config.py
+++ b/host/config.py
@@ -99,15 +99,29 @@ IDLE_TIMEOUT = _env_int("IDLE_TIMEOUT", 30 * 60 * 1000) / 1000
 MAX_CONCURRENT_CONTAINERS = _env_int("MAX_CONCURRENT_CONTAINERS", 5, minimum=1)
 # Per-container resource limits (Issue #61): prevent runaway agents from OOM-killing the host.
 # Set to empty string "" to disable the limit (e.g. CONTAINER_MEMORY="" CONTAINER_CPUS="").
-# Default raised to 2g (from 1g): loading a single LLM SDK (google-genai/openai/anthropic)
-# uses 50-200 MB; with Python overhead + conversation history + response buffers,
-# 1g was insufficient for complex multi-turn sessions → OOM exit 137.
-# The lazy-import fix (agent.py) also reduces footprint, but 2g provides a safe margin.
+#
+# CONTAINER_MEMORY history:
+#   1g  (initial)   — too tight; complex multi-turn sessions OOM'd on SDK load
+#   2g  (bump)      — raised to mask memory bloat; never actually needed at steady state
+#   512m (current)  — Issue #528 / PR after #527 (tool_grep streaming fix).
+#     Post-bug analysis showed steady-state agent-process RSS is 80-150 MB:
+#     Python + stdlib ~15 MB, local modules ~5 MB, one lazy-loaded LLM SDK
+#     (google-genai / openai / anthropic) 40-90 MB. `_tools.py` has ZERO
+#     eager imports of pandas/numpy/matplotlib/lxml — data-science packages
+#     are only pulled in when the agent shells out via `tool_bash`, and those
+#     subprocesses release memory on exit. The 2g default was masking a single
+#     bug in `tool_grep` (subprocess.run capture_output=True reading full
+#     stdout before truncating) that has now been fixed in #527. 512 MB gives
+#     ~3× headroom over the real working set.
+#   Override: if you run extremely long openai/claude contexts, set
+#     CONTAINER_MEMORY=768m (or higher) in .env. Do NOT revert to 2g — 2g was
+#     never calibrated, it was a band-aid.
+#
 # BUG-FIX: os.environ.get() alone misses values written in the .env file because
 # read_env_file() does NOT inject into os.environ.  Use the same two-level fallback
 # pattern as ENABLED_CHANNELS: env-var takes priority, then .env file, then default.
 _env_file_resources = read_env_file(["CONTAINER_MEMORY", "CONTAINER_CPUS"])
-CONTAINER_MEMORY = os.environ.get("CONTAINER_MEMORY") or _env_file_resources.get("CONTAINER_MEMORY", "2g")
+CONTAINER_MEMORY = os.environ.get("CONTAINER_MEMORY") or _env_file_resources.get("CONTAINER_MEMORY", "512m")
 CONTAINER_CPUS = os.environ.get("CONTAINER_CPUS") or _env_file_resources.get("CONTAINER_CPUS", "1.0")
 # CONTAINER_PIDS_LIMIT: maximum number of processes the container may spawn.
 # Prevents fork bombs inside an untrusted agent container.


### PR DESCRIPTION
Closes #528

## Summary

Lower `CONTAINER_MEMORY` default from `"2g"` to `"512m"` in `host/config.py:110`. This is the follow-up to the #527 / tool_grep streaming fix — it converts the newly-recovered memory headroom into a real per-container budget.

## Why 512m is the right number

Post-#527 analysis of the agent process footprint:

| Component | Estimated RSS |
|-----------|--------------|
| Python interpreter + stdlib | ~15 MB |
| Local modules (`_tools/_utils/_constants/_registry/_loop_*`) | ~5 MB |
| One lazy-loaded LLM SDK (google-genai / openai / anthropic) | 40-90 MB |
| Conversation history (pre-L2) | negligible |
| Single tool_result (post-#527, ≤ 8 KB per call) | negligible |
| **Steady-state RSS** | **80-120 MB** |

`container/agent-runner/_tools.py` has **zero** module-level imports of pandas, numpy, matplotlib, Pillow, lxml, beautifulsoup — data-science packages pre-installed in the Dockerfile are only reachable via `tool_bash` subprocesses, and subprocess RSS releases on exit.

Steady state ~100 MB → 512 MB gives >3× headroom. The old 2 GB default was never calibrated, it was a band-aid for the bug fixed in #527.

## Aggregate impact

With `MAX_CONCURRENT_CONTAINERS=5` default:
- Before: 5 × 2 GB = **10 GB** peak
- After: 5 × 512 MB = **2.5 GB** peak

This makes EvoClaw comfortable on hosts with ≤ 16 GB RAM, where the previous default would fight the host process for memory.

## Changes

- `host/config.py:110` — default changed to `"512m"`
- `host/config.py:100-120` — expanded comment to document full 1g → 2g → 512m history with rationale
- `docs/CHANGELOG.md` — `[1.27.2]` entry under `### Changed`

## Test plan

- [x] Existing config loading paths unchanged (env var override still wins)
- [ ] Post-merge smoke test: run a Level-A openai-compat session with the typical workload and confirm no OOM, container RSS stays < 400 MB
- [ ] Run a wide-Grep session against a main-group container and confirm the streaming cap from #527 keeps RSS bounded

## Rollback guidance

If 512 MB proves too tight for any real workload, raise to `768m`, not back to `2g`. The comment block in `host/config.py` now explains why.

## Depends on

- #527 (merged) — tool_grep streaming fix. Without it, 512 MB is unsafe under wide-grep workloads.
