### PR TITLE
feat(self_update): test gate + scheduled auto-update trigger (#530)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.27.3] — 2026-04-10
+
+### Added
+- **Test gate + scheduled auto-update trigger for `self_update`.** `_run_self_update` in `host/ipc_watcher.py` now runs a short pytest suite between `git pull` and writing `self_update.flag`; on non-zero exit it `git reset --hard`s back to the pre-pull SHA and aborts the update, so a broken commit on `main` can no longer roll straight into an `os.execv` restart. A new `host/auto_update.py` module adds an optional scheduled loop (gated on `AUTO_UPDATE_ENABLED=true`, default off) that `git fetch`es every `AUTO_UPDATE_INTERVAL_SECS` (default 3600) and invokes `_run_self_update` whenever local HEAD is behind `origin/<branch>`. Also documents — in an inline comment in `host/main.py` — why the restart continues to use `os.execv` rather than shelling out to `pm2 restart` (keeps supervisor PID stable, no dependency on pm2 being on PATH / daemon alive, pm2 `autorestart: true` remains the crash safety net). (#530)
+
+### Technical Details
+- **New Files**: `host/auto_update.py`, `tests/test_self_update_test_gate.py`
+- **Modified Files**: `host/ipc_watcher.py` (test gate block after git pull), `host/config.py` (`AUTO_UPDATE_ENABLED`, `AUTO_UPDATE_INTERVAL_SECS`, `AUTO_UPDATE_BRANCH`, `AUTO_UPDATE_TEST_CMD`), `host/main.py` (wires `auto_update_loop` into the main gather, adds os.execv rationale comment)
+- **New Env Vars**:
+  - `AUTO_UPDATE_ENABLED` (default `false`) — enable the scheduled auto-update loop.
+  - `AUTO_UPDATE_INTERVAL_SECS` (default `3600`, min `60`) — seconds between fetch checks.
+  - `AUTO_UPDATE_BRANCH` (default `main`) — remote branch to track.
+  - `AUTO_UPDATE_TEST_CMD` (default `pytest -x --timeout=60 -q tests/`) — test command run inside `_run_self_update` after `git pull`. Set to empty string to skip the gate (not recommended).
+- **Breaking Changes**: None. Default behaviour (no env vars set) is unchanged except that manual IPC-triggered `self_update` calls now run the test gate too — updates that fail tests will be rolled back instead of restarting. This is the intended safety improvement.
+- **Security**: The scheduled loop bypasses the `SELF_UPDATE_TOKEN` IPC gate intentionally. That token exists to block prompt-injection attacks flowing from an LLM agent into the IPC handler; the scheduled loop runs in trusted host code with no attacker-controlled input.
+
 ## [1.27.2] — 2026-04-10
 
 ### Changed

--- a/host/auto_update.py
+++ b/host/auto_update.py
@@ -1,0 +1,137 @@
+"""Scheduled auto-update loop (Issue #530).
+
+Periodically runs ``git fetch`` against the project repo and, when ``HEAD`` is
+behind ``origin/<branch>``, invokes :func:`host.ipc_watcher._run_self_update`
+to pull, test-gate, and (on success) write ``self_update.flag`` so the host
+main loop performs an in-place restart via ``os.execv``.
+
+Design notes
+------------
+* This path **bypasses the SELF_UPDATE_TOKEN IPC gate** intentionally.  The
+  token exists to block prompt-injection attacks that flow from an LLM agent
+  into the IPC handler; the scheduled loop runs in trusted host code and has
+  no attacker-controlled input, so requiring a token here would add no
+  security but would turn auto-update into a manual ritual.
+* Enabled only when ``AUTO_UPDATE_ENABLED=true``.  Default is disabled so
+  existing deployments see zero behaviour change on upgrade.
+* Uses the **existing** ``_run_self_update`` implementation for the actual
+  work — test gate, pip install, flag write, restart — so there is exactly
+  one code path that mutates the working tree.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Callable
+
+from . import config
+
+log = logging.getLogger(__name__)
+
+
+async def _noop_route(_jid: str, _text: str) -> None:  # pragma: no cover - trivial
+    """Route fn used when the auto-update loop has no chat to notify."""
+    return None
+
+
+async def _git_is_behind(cwd: str, branch: str) -> bool:
+    """Return True iff local HEAD is strictly behind ``origin/<branch>``.
+
+    Runs ``git fetch`` first; on any fetch/rev-list failure returns ``False``
+    (fail-safe: a transient network glitch should not trigger rollback churn).
+    """
+    # git fetch origin <branch>
+    fetch_proc = await asyncio.create_subprocess_exec(
+        "git", "fetch", "origin", branch,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        cwd=cwd,
+    )
+    try:
+        await asyncio.wait_for(fetch_proc.communicate(), timeout=60.0)
+    except asyncio.TimeoutError:
+        try:
+            fetch_proc.kill()
+        except Exception:
+            pass
+        log.warning("auto_update: git fetch timed out")
+        return False
+    if fetch_proc.returncode != 0:
+        log.warning("auto_update: git fetch exit=%s", fetch_proc.returncode)
+        return False
+
+    # git rev-list --count HEAD..origin/<branch>
+    rl_proc = await asyncio.create_subprocess_exec(
+        "git", "rev-list", "--count", f"HEAD..origin/{branch}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+    )
+    try:
+        rl_out, _ = await asyncio.wait_for(rl_proc.communicate(), timeout=30.0)
+    except asyncio.TimeoutError:
+        try:
+            rl_proc.kill()
+        except Exception:
+            pass
+        return False
+    if rl_proc.returncode != 0:
+        return False
+    try:
+        count = int(rl_out.decode("utf-8", errors="replace").strip() or "0")
+    except ValueError:
+        return False
+    return count > 0
+
+
+async def auto_update_loop(stop_event: asyncio.Event) -> None:
+    """Main entry point, called from ``host.main``.
+
+    Runs forever until ``stop_event`` is set.  Yields control to ``asyncio``
+    between iterations so cancellation on shutdown is near-instant.
+    """
+    if not config.AUTO_UPDATE_ENABLED:
+        log.info("auto_update: disabled (AUTO_UPDATE_ENABLED != true)")
+        return
+
+    # Import lazily to avoid circular import with ipc_watcher at module load.
+    from .ipc_watcher import _run_self_update
+
+    interval = max(60, int(config.AUTO_UPDATE_INTERVAL_SECS))
+    branch = config.AUTO_UPDATE_BRANCH or "main"
+    cwd = str(config.BASE_DIR)
+    log.info(
+        "auto_update: enabled — interval=%ss branch=%s cwd=%s",
+        interval, branch, cwd,
+    )
+
+    # First check happens after one full interval, not immediately.  Restarts
+    # triggered by config reloads shouldn't cause a stampede of `git fetch`.
+    try:
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval)
+                return  # stop_event fired — graceful exit
+            except asyncio.TimeoutError:
+                pass  # interval elapsed — run one check
+
+            try:
+                behind = await _git_is_behind(cwd, branch)
+            except Exception as exc:  # pragma: no cover - defensive
+                log.warning("auto_update: _git_is_behind raised: %s", exc)
+                continue
+            if not behind:
+                log.debug("auto_update: up to date")
+                continue
+
+            log.info("auto_update: behind origin/%s — triggering self_update", branch)
+            try:
+                # jid="" → no user-facing chat output; this is a background
+                # trigger.  _run_self_update handles the test gate + flag.
+                await _run_self_update("", _noop_route)
+            except Exception as exc:
+                log.error("auto_update: _run_self_update raised: %s", exc)
+    except asyncio.CancelledError:
+        log.info("auto_update: cancelled")
+        raise

--- a/host/config.py
+++ b/host/config.py
@@ -243,6 +243,25 @@ EDITABLE_ENV_KEYS: frozenset = frozenset({
 # Database (optional — defaults to SQLite)
 DATABASE_URL: str = os.environ.get("DATABASE_URL", "")  # e.g. postgresql://user:pass@host:5432/dbname
 
+# Auto-update (Issue #530)
+# Enable the scheduled loop that periodically runs `git fetch` against the
+# project repo and, when HEAD is behind origin/<branch>, calls the existing
+# _run_self_update path (test-gated `git pull` + `self_update.flag` + os.execv
+# restart).  Defaults OFF so existing deployments see zero behaviour change.
+AUTO_UPDATE_ENABLED: bool = os.environ.get("AUTO_UPDATE_ENABLED", "false").lower() == "true"
+# Interval between checks.  Minimum 60s enforced inside the loop.
+AUTO_UPDATE_INTERVAL_SECS: int = _env_int("AUTO_UPDATE_INTERVAL_SECS", 3600, minimum=60)
+# Branch to track.  Typically "main".
+AUTO_UPDATE_BRANCH: str = os.environ.get("AUTO_UPDATE_BRANCH", "main")
+# Test command run by _run_self_update between `git pull` and writing the
+# restart flag.  A non-zero exit causes `git reset --hard` rollback to the
+# pre-pull SHA, and the flag is not written.  Set to empty string to skip the
+# gate entirely (not recommended — a broken commit on main would crash-loop
+# the host until pm2 autorestart gives up).
+AUTO_UPDATE_TEST_CMD: str = os.environ.get(
+    "AUTO_UPDATE_TEST_CMD", "pytest -x --timeout=60 -q tests/"
+)
+
 # Multi-instance Leader Election
 LEADER_ELECTION_ENABLED: bool = os.environ.get("LEADER_ELECTION_ENABLED", "false").lower() == "true"
 LEADER_HEARTBEAT_INTERVAL: int = _env_int("LEADER_HEARTBEAT_INTERVAL", 10)  # p12b fix: use _env_int for safe coercion

--- a/host/ipc_watcher.py
+++ b/host/ipc_watcher.py
@@ -1048,6 +1048,89 @@ async def _run_self_update(jid: str, route_fn: Callable) -> None:
                 await route_fn(jid, msg)
             return
 
+        # ── Test gate (Issue #530) ────────────────────────────────────────────
+        # Between `git pull` and writing self_update.flag we run a short test
+        # suite.  If it fails we `git reset --hard` back to the pre-pull SHA so
+        # the next restart does NOT pick up broken code.  Without this gate a
+        # bad commit on main would roll straight into a crash-loop that only
+        # pm2's autorestart can (eventually) give up on.
+        #
+        # Skip the gate when:
+        #   * Already up-to-date (nothing to test).
+        #   * AUTO_UPDATE_TEST_CMD is set to empty string (explicit opt-out).
+        _already_up_to_date = "Already up to date." in git_output
+        _test_cmd_raw = os.environ.get(
+            "AUTO_UPDATE_TEST_CMD",
+            "pytest -x --timeout=60 -q tests/",
+        )
+        if (not _already_up_to_date) and _test_cmd_raw.strip():
+            # Capture the pre-pull SHA so we can roll back on test failure.
+            _rev_proc = await asyncio.create_subprocess_exec(
+                "git", "rev-parse", "HEAD@{1}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+            )
+            _rev_stdout, _ = await _rev_proc.communicate()
+            _pre_pull_sha = _rev_stdout.decode("utf-8", errors="replace").strip()
+
+            if jid:
+                await route_fn(jid, "🧪 執行測試閘門...")
+            log.info("self_update: running test gate: %s", _test_cmd_raw)
+
+            import shlex as _shlex
+            _test_argv = _shlex.split(_test_cmd_raw)
+            test_proc = await asyncio.create_subprocess_exec(
+                *_test_argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=cwd,
+            )
+            try:
+                # Hard cap: 10 minutes for the gate suite.
+                test_stdout, _ = await asyncio.wait_for(
+                    test_proc.communicate(), timeout=600.0
+                )
+                test_rc = test_proc.returncode
+            except asyncio.TimeoutError:
+                try:
+                    test_proc.kill()
+                except Exception:
+                    pass
+                test_stdout = b"(test gate timed out after 600s)"
+                test_rc = -1
+
+            test_output = test_stdout.decode("utf-8", errors="replace")
+            if test_rc != 0:
+                log.error(
+                    "self_update: test gate FAILED (rc=%s) — rolling back to %s",
+                    test_rc, _pre_pull_sha or "HEAD@{1}",
+                )
+                # Roll back the working tree to the pre-pull state.
+                _rollback_target = _pre_pull_sha or "HEAD@{1}"
+                rb_proc = await asyncio.create_subprocess_exec(
+                    "git", "reset", "--hard", _rollback_target,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    cwd=cwd,
+                )
+                try:
+                    await asyncio.wait_for(rb_proc.communicate(), timeout=30.0)
+                except asyncio.TimeoutError:
+                    try:
+                        rb_proc.kill()
+                    except Exception:
+                        pass
+                    log.error("self_update: rollback git reset --hard timed out")
+                if jid:
+                    _tail = test_output[-800:] if len(test_output) > 800 else test_output
+                    await route_fn(jid, (
+                        f"❌ 測試閘門失敗 (exit {test_rc})，已 rollback 到 {_rollback_target[:12]}，"
+                        f"放棄此次更新。\n```\n{_tail}\n```"
+                    ))
+                return
+            log.info("self_update: test gate passed (rc=0)")
+
         # ── pip install -e . (optional, only if project has setup files) ──────
         _pip_marker = _pathlib.Path(cwd) / "pyproject.toml"
         _setup_marker = _pathlib.Path(cwd) / "setup.py"

--- a/host/main.py
+++ b/host/main.py
@@ -1789,6 +1789,13 @@ async def main() -> None:
             health_monitor_loop(_stop_event),
             _orphan_cleanup_loop(_stop_event),
         ]
+        # Issue #530: scheduled auto-update (git fetch → pull → test → restart)
+        # Gated by AUTO_UPDATE_ENABLED; no-op otherwise.
+        try:
+            from .auto_update import auto_update_loop
+            _gather_tasks.append(auto_update_loop(_stop_event))
+        except Exception as _au_exc:  # pragma: no cover - defensive
+            log.warning("auto_update loop not started: %s", _au_exc)
         # Phase 1 (UnifiedClaw): WebSocket bridge — coexists with file IPC
         if _ws_bridge is not None:
             _gather_tasks.append(_ws_bridge.start())
@@ -1851,7 +1858,21 @@ async def main() -> None:
     log.info("EvoClaw shut down cleanly.")
 
     # Self-update: replace current process with a fresh one so updated code is loaded.
-    # os.execv() replaces the running process in-place (Unix) or spawns a replacement (Windows).
+    #
+    # Design note (Issue #530): we intentionally use `os.execv` here rather than
+    # shelling out to `pm2 restart evoclaw`.  Rationale:
+    #   * os.execv keeps the pm2 supervisor PID stable — pm2 sees a single
+    #     long-lived worker, not a parent that exited.  Restart counters and
+    #     uptime stats stay sensible.
+    #   * `pm2 restart` would require pm2 to be on PATH and the pm2 daemon to
+    #     be running inside this environment; in edge cases (e.g. pm2 daemon
+    #     crashed, or EvoClaw launched directly for debugging) that call
+    #     would hang or fail and the update would get stuck.
+    #   * pm2's `autorestart: true` is still our crash safety net: if os.execv
+    #     itself fails or the replacement process crashes at startup, pm2
+    #     will respawn us.
+    # If you are tempted to "fix" this by switching to pm2 restart, read the
+    # issue #530 discussion first.
     if _self_update_requested:
         import sys as _sys_restart
         log.info("Restarting EvoClaw for self-update via os.execv()...")

--- a/tests/test_self_update_test_gate.py
+++ b/tests/test_self_update_test_gate.py
@@ -1,0 +1,162 @@
+"""Tests for Issue #530 — test gate + rollback in _run_self_update.
+
+The self_update flow must:
+  1. Run `git pull` (already tested indirectly elsewhere).
+  2. If the pull brought new commits, run a test command.
+  3. On test failure, `git reset --hard` back to the pre-pull SHA and
+     NOT write self_update.flag (so no restart into broken code).
+  4. On test success, proceed to pip install + flag write.
+
+These tests build a real throwaway git repo so the subprocess code paths
+(git pull, git rev-parse HEAD@{1}, git reset --hard) execute against real
+git, not mocks.  The test command is swapped via the AUTO_UPDATE_TEST_CMD
+env var to a trivial `python -c` that either exits 0 or exits 1.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git not available on PATH"
+)
+
+
+def _run(*args, cwd):
+    """Small git helper — silent, raises on failure."""
+    subprocess.run(
+        args,
+        cwd=str(cwd),
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@pytest.fixture
+def fake_repo(tmp_path):
+    """Build a bare-ish origin + a working clone with one initial commit.
+
+    Layout::
+
+        tmp_path/origin.git/       bare repo acting as "origin"
+        tmp_path/work/             working clone, set as project BASE_DIR
+    """
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _run("git", "init", "--bare", "-b", "main", ".", cwd=origin)
+
+    work = tmp_path / "work"
+    work.mkdir()
+    _run("git", "init", "-b", "main", ".", cwd=work)
+    _run("git", "config", "user.email", "t@t", cwd=work)
+    _run("git", "config", "user.name", "t", cwd=work)
+    _run("git", "config", "commit.gpgsign", "false", cwd=work)
+    (work / "hello.txt").write_text("v1\n")
+    _run("git", "add", "hello.txt", cwd=work)
+    _run("git", "commit", "-m", "v1", cwd=work)
+    _run("git", "remote", "add", "origin", str(origin), cwd=work)
+    _run("git", "push", "-u", "origin", "main", cwd=work)
+
+    # Publish a second commit *only* on the origin, then roll work back one
+    # commit so `git pull` will actually fast-forward.
+    tmp_clone = tmp_path / "tmp_clone"
+    _run("git", "clone", str(origin), str(tmp_clone), cwd=tmp_path)
+    _run("git", "config", "user.email", "t@t", cwd=tmp_clone)
+    _run("git", "config", "user.name", "t", cwd=tmp_clone)
+    _run("git", "config", "commit.gpgsign", "false", cwd=tmp_clone)
+    (tmp_clone / "hello.txt").write_text("v2\n")
+    _run("git", "add", "hello.txt", cwd=tmp_clone)
+    _run("git", "commit", "-m", "v2", cwd=tmp_clone)
+    _run("git", "push", "origin", "main", cwd=tmp_clone)
+
+    # Now `git pull` inside `work` will move from v1 to v2.
+    return work
+
+
+def _patch_base_dir(monkeypatch, repo: Path, data_dir: Path):
+    """Point host.config.BASE_DIR / DATA_DIR at our fake repo."""
+    from host import config as _cfg
+    monkeypatch.setattr(_cfg, "BASE_DIR", repo)
+    monkeypatch.setattr(_cfg, "DATA_DIR", data_dir)
+    data_dir.mkdir(exist_ok=True)
+
+
+def _current_sha(repo: Path) -> str:
+    out = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=str(repo))
+    return out.decode().strip()
+
+
+async def _noop_route(_jid, _text):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_test_gate_failure_rolls_back_and_no_flag(fake_repo, tmp_path, monkeypatch):
+    """Failing test command → git reset --hard to pre-pull SHA, no flag written."""
+    data_dir = tmp_path / "data"
+    _patch_base_dir(monkeypatch, fake_repo, data_dir)
+
+    # Force the test command to fail deterministically.
+    monkeypatch.setenv("AUTO_UPDATE_TEST_CMD", f'"{sys.executable}" -c "import sys; sys.exit(1)"')
+
+    pre_sha = _current_sha(fake_repo)
+    assert (fake_repo / "hello.txt").read_text() == "v1\n"
+
+    from host.ipc_watcher import _run_self_update
+    await _run_self_update("", _noop_route)
+
+    # Working tree must be back at the pre-pull SHA.
+    assert _current_sha(fake_repo) == pre_sha, "rollback to pre-pull SHA failed"
+    assert (fake_repo / "hello.txt").read_text() == "v1\n", "working tree not rolled back"
+    # Flag must NOT be written — broken code must not trigger a restart.
+    assert not (data_dir / "self_update.flag").exists()
+
+
+@pytest.mark.asyncio
+async def test_test_gate_success_writes_flag(fake_repo, tmp_path, monkeypatch):
+    """Passing test command → working tree at new SHA, flag written."""
+    data_dir = tmp_path / "data"
+    _patch_base_dir(monkeypatch, fake_repo, data_dir)
+
+    monkeypatch.setenv("AUTO_UPDATE_TEST_CMD", f'"{sys.executable}" -c "import sys; sys.exit(0)"')
+
+    pre_sha = _current_sha(fake_repo)
+
+    from host.ipc_watcher import _run_self_update
+    await _run_self_update("", _noop_route)
+
+    post_sha = _current_sha(fake_repo)
+    assert post_sha != pre_sha, "git pull did not advance HEAD"
+    assert (fake_repo / "hello.txt").read_text() == "v2\n"
+    assert (data_dir / "self_update.flag").exists(), "flag not written after successful gate"
+
+
+@pytest.mark.asyncio
+async def test_already_up_to_date_skips_gate(fake_repo, tmp_path, monkeypatch):
+    """If git pull is a no-op, the test gate is skipped and flag is still written.
+
+    (Existing behaviour — present before #530 — preserved as a regression guard.)
+    """
+    # Fast-forward first so there is nothing to pull.
+    _run("git", "pull", "origin", "main", cwd=fake_repo)
+
+    data_dir = tmp_path / "data"
+    _patch_base_dir(monkeypatch, fake_repo, data_dir)
+
+    # A test command that WOULD fail if it ran — proves the gate was skipped.
+    monkeypatch.setenv("AUTO_UPDATE_TEST_CMD", f'"{sys.executable}" -c "import sys; sys.exit(1)"')
+
+    from host.ipc_watcher import _run_self_update
+    await _run_self_update("", _noop_route)
+
+    assert (data_dir / "self_update.flag").exists()


### PR DESCRIPTION
Closes #530

## Summary

Closes the three gaps in the current `self_update` flow identified in #530:

1. **Test gate** — `_run_self_update` now runs \`AUTO_UPDATE_TEST_CMD\` (default \`pytest -x --timeout=60 -q tests/\`) after \`git pull\`. On non-zero exit, it \`git reset --hard\`s back to the pre-pull SHA and aborts the update. No flag write, no \`os.execv\` into broken code.
2. **Scheduled auto-trigger** — new \`host/auto_update.py\` module with an \`auto_update_loop\` coroutine wired into the main gather. Gated on \`AUTO_UPDATE_ENABLED=true\` (default **false**, so existing deployments see zero behaviour change). Every \`AUTO_UPDATE_INTERVAL_SECS\` (default 3600, min 60) runs \`git fetch\` and, if local HEAD is behind \`origin/<branch>\`, calls the existing \`_run_self_update\`.
3. **Documented \`os.execv\` decision** — inline comment in \`host/main.py\` explains why the restart is not switched to \`pm2 restart\` (stable supervisor PID, no dependency on pm2 daemon being up, pm2 \`autorestart: true\` remains the crash safety net).

## Why bypass SELF_UPDATE_TOKEN in the scheduled loop

The token exists to block prompt-injection attacks flowing from an LLM agent into the IPC \`self_update\` handler. The scheduled loop runs in trusted host code with no attacker-controlled input — requiring a token there would add no security, only operational friction.

## Changes

- \`host/ipc_watcher.py\` — test gate block inserted between \`git pull\` success and \`pip install\`. Uses \`HEAD@{1}\` via \`git rev-parse\` to capture pre-pull SHA, then \`git reset --hard\` on failure. 10-minute hard cap on the gate suite.
- \`host/auto_update.py\` — **new**. \`_git_is_behind(cwd, branch)\` helper (\`git fetch\` + \`git rev-list --count HEAD..origin/<branch>\`, fail-safe), \`auto_update_loop(stop_event)\` main coroutine.
- \`host/main.py\` — appends \`auto_update_loop\` to \`_gather_tasks\`; inline \`os.execv\` rationale comment above line 1862.
- \`host/config.py\` — \`AUTO_UPDATE_ENABLED\`, \`AUTO_UPDATE_INTERVAL_SECS\`, \`AUTO_UPDATE_BRANCH\`, \`AUTO_UPDATE_TEST_CMD\`.
- \`tests/test_self_update_test_gate.py\` — **new**. 3 tests building a real throwaway git repo (origin.git + work clone + second commit on origin) so the subprocess code paths run against real git:
  - \`test_test_gate_failure_rolls_back_and_no_flag\` — forces failing test cmd, asserts HEAD back at pre-pull SHA and no \`self_update.flag\`.
  - \`test_test_gate_success_writes_flag\` — forces passing test cmd, asserts HEAD advanced and flag present.
  - \`test_already_up_to_date_skips_gate\` — regression guard: no-op pull skips the gate entirely.
- \`docs/CHANGELOG.md\` — \`[1.27.3]\` under \`### Added\`.

## Test plan

- [x] \`pytest tests/test_self_update_test_gate.py -q\` → 3 passed
- [x] \`pytest tests/test_tool_grep_streaming.py -q\` still green
- [x] \`python -c \"import host.auto_update, host.ipc_watcher, host.main\"\` — no import errors, \`AUTO_UPDATE_ENABLED\` defaults to False
- [ ] Post-merge smoke: set \`AUTO_UPDATE_ENABLED=true AUTO_UPDATE_INTERVAL_SECS=120\` in a staging \`.env\`, push a trivial commit to \`main\`, observe host picks it up within 2 minutes and restarts cleanly via pm2.
- [ ] Negative smoke: push a commit that intentionally breaks a cheap test, observe rollback and no restart.

## Rollback guidance

If the test gate causes issues, operators can set \`AUTO_UPDATE_TEST_CMD=\"\"\` to skip the gate (restores pre-#530 behaviour) without reverting this PR. If the scheduled loop misbehaves, unset \`AUTO_UPDATE_ENABLED\`.