### PR TITLE
fix(config): read AUTO_UPDATE_* from .env via two-level fallback (#532)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.27.4] — 2026-04-11
+
+### Fixed
+- **`AUTO_UPDATE_*` keys in `.env` silently ignored.** `host/config.py` read the new #530 auto-update keys via plain `os.environ.get(...)`, but EvoClaw's `.env` loader (`host/env.py:read_env_file`) is deliberately non-polluting — it returns a dict, it does not set `os.environ[k]`. Result: putting `AUTO_UPDATE_ENABLED=true` in `.env` had no effect; the loop stayed disabled until operators also set a shell env var. Fixed by applying the same two-level fallback pattern already used by `CONTAINER_MEMORY` / `ENABLED_CHANNELS` (env var → `.env` file → default) to all four `AUTO_UPDATE_*` keys. `_run_self_update` in `host/ipc_watcher.py` now reads `AUTO_UPDATE_TEST_CMD` via the config module (with env-var override still winning) instead of hitting `os.environ` twice. (#532)
+
+### Technical Details
+- **Modified Files**: `host/config.py`, `host/ipc_watcher.py`
+- **Breaking Changes**: None. Shell env-var override still wins over `.env`; the only behaviour change is that operators who put `AUTO_UPDATE_*` in `.env` (as the #530 README said to) now actually get what they asked for.
+
 ## [1.27.3] — 2026-04-10
 
 ### Added

--- a/host/config.py
+++ b/host/config.py
@@ -248,18 +248,43 @@ DATABASE_URL: str = os.environ.get("DATABASE_URL", "")  # e.g. postgresql://user
 # project repo and, when HEAD is behind origin/<branch>, calls the existing
 # _run_self_update path (test-gated `git pull` + `self_update.flag` + os.execv
 # restart).  Defaults OFF so existing deployments see zero behaviour change.
-AUTO_UPDATE_ENABLED: bool = os.environ.get("AUTO_UPDATE_ENABLED", "false").lower() == "true"
+#
+# BUG-FIX (#530 follow-up): `read_env_file()` does NOT populate os.environ,
+# so a plain `os.environ.get("AUTO_UPDATE_ENABLED")` would silently ignore
+# the value written in `.env`.  Use the same two-level fallback pattern as
+# CONTAINER_MEMORY / ENABLED_CHANNELS: env-var wins, then .env file, then default.
+_env_file_autoupdate = read_env_file([
+    "AUTO_UPDATE_ENABLED",
+    "AUTO_UPDATE_INTERVAL_SECS",
+    "AUTO_UPDATE_BRANCH",
+    "AUTO_UPDATE_TEST_CMD",
+])
+AUTO_UPDATE_ENABLED: bool = (
+    os.environ.get("AUTO_UPDATE_ENABLED")
+    or _env_file_autoupdate.get("AUTO_UPDATE_ENABLED", "false")
+).lower() == "true"
 # Interval between checks.  Minimum 60s enforced inside the loop.
-AUTO_UPDATE_INTERVAL_SECS: int = _env_int("AUTO_UPDATE_INTERVAL_SECS", 3600, minimum=60)
+try:
+    _auto_upd_interval_raw = (
+        os.environ.get("AUTO_UPDATE_INTERVAL_SECS")
+        or _env_file_autoupdate.get("AUTO_UPDATE_INTERVAL_SECS", "3600")
+    )
+    AUTO_UPDATE_INTERVAL_SECS: int = max(60, int(_auto_upd_interval_raw))
+except (ValueError, TypeError):
+    AUTO_UPDATE_INTERVAL_SECS = 3600
 # Branch to track.  Typically "main".
-AUTO_UPDATE_BRANCH: str = os.environ.get("AUTO_UPDATE_BRANCH", "main")
+AUTO_UPDATE_BRANCH: str = (
+    os.environ.get("AUTO_UPDATE_BRANCH")
+    or _env_file_autoupdate.get("AUTO_UPDATE_BRANCH", "main")
+)
 # Test command run by _run_self_update between `git pull` and writing the
 # restart flag.  A non-zero exit causes `git reset --hard` rollback to the
 # pre-pull SHA, and the flag is not written.  Set to empty string to skip the
 # gate entirely (not recommended — a broken commit on main would crash-loop
 # the host until pm2 autorestart gives up).
-AUTO_UPDATE_TEST_CMD: str = os.environ.get(
-    "AUTO_UPDATE_TEST_CMD", "pytest -x --timeout=60 -q tests/"
+AUTO_UPDATE_TEST_CMD: str = (
+    os.environ.get("AUTO_UPDATE_TEST_CMD")
+    or _env_file_autoupdate.get("AUTO_UPDATE_TEST_CMD", "pytest -x --timeout=60 -q tests/")
 )
 
 # Multi-instance Leader Election

--- a/host/ipc_watcher.py
+++ b/host/ipc_watcher.py
@@ -1059,9 +1059,12 @@ async def _run_self_update(jid: str, route_fn: Callable) -> None:
         #   * Already up-to-date (nothing to test).
         #   * AUTO_UPDATE_TEST_CMD is set to empty string (explicit opt-out).
         _already_up_to_date = "Already up to date." in git_output
+        # Honour env-var override, then fall back to config (which itself
+        # reads .env).  Matches the two-level pattern used elsewhere so
+        # operators editing .env see their changes take effect after restart.
         _test_cmd_raw = os.environ.get(
             "AUTO_UPDATE_TEST_CMD",
-            "pytest -x --timeout=60 -q tests/",
+            getattr(config, "AUTO_UPDATE_TEST_CMD", "pytest -x --timeout=60 -q tests/"),
         )
         if (not _already_up_to_date) and _test_cmd_raw.strip():
             # Capture the pre-pull SHA so we can roll back on test failure.


### PR DESCRIPTION
Closes #532

## Summary

Follow-up fix to #530. `host/config.py` was reading the new `AUTO_UPDATE_*` keys via plain `os.environ.get(...)`, but `host/env.py:read_env_file` is deliberately non-polluting (it returns a dict, doesn't touch `os.environ`). So \`AUTO_UPDATE_ENABLED=true\` in \`.env\` had zero effect and the scheduled loop stayed disabled.

## Fix

Same two-level fallback pattern already used by `CONTAINER_MEMORY` and `ENABLED_CHANNELS`:

\`\`\`python
_env_file_autoupdate = read_env_file([
    \"AUTO_UPDATE_ENABLED\",
    \"AUTO_UPDATE_INTERVAL_SECS\",
    \"AUTO_UPDATE_BRANCH\",
    \"AUTO_UPDATE_TEST_CMD\",
])
AUTO_UPDATE_ENABLED = (
    os.environ.get(\"AUTO_UPDATE_ENABLED\")
    or _env_file_autoupdate.get(\"AUTO_UPDATE_ENABLED\", \"false\")
).lower() == \"true\"
\`\`\`

\`_run_self_update\` in \`host/ipc_watcher.py\` also switched to \`getattr(config, \"AUTO_UPDATE_TEST_CMD\", ...)\` fallback so operators editing \`.env\` see their changes after restart without having to also \`export\` the variable.

## Verification

\`\`\`console
$ python -c \"import host.config as c; print(c.AUTO_UPDATE_ENABLED, c.AUTO_UPDATE_INTERVAL_SECS, c.AUTO_UPDATE_BRANCH)\"
True 3600 main
\`\`\`

With \`.env\` containing only \`AUTO_UPDATE_ENABLED=true\` (no shell env var set).

## Test plan

- [x] \`pytest tests/test_self_update_test_gate.py -q\` → 3 passed (still green)
- [x] Config import prints expected values from \`.env\`-only
- [ ] Post-merge: \`pm2 restart evoclaw --update-env\`, confirm log shows \`auto_update: enabled — interval=3600s branch=main ...\`