### PR TITLE
fix(windows): CREATE_NO_WINDOW on ipc_watcher + auto_update subprocesses (#534)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.27.5] — 2026-04-11
+
+### Fixed
+- **Transient console windows flashing on Windows during self-update and auto-update.** `host/ipc_watcher.py` (6 subprocess call sites: claude remote-control, git pull, git rev-parse, pytest gate, git reset --hard, pip install) and the new `host/auto_update.py` (git fetch, git rev-list) did not pass `creationflags=CREATE_NO_WINDOW` when spawning child processes. On Windows this caused a brief `cmd.exe` / `console` window to pop up for every spawn — now visible every hour once `AUTO_UPDATE_ENABLED=true` was rolled out in production. `host/container_runner.py` and `host/dashboard.py` already had this handled via a `_NO_WINDOW` constant; applied the same pattern to the two remaining modules. Linux behaviour unchanged (`_NO_WINDOW = 0` is a no-op). (#534)
+
+### Technical Details
+- **Modified Files**: `host/ipc_watcher.py` (added `_NO_WINDOW` constant + `creationflags` on all 6 `create_subprocess_exec` calls), `host/auto_update.py` (same, 2 calls).
+- **Breaking Changes**: None.
+
 ## [1.27.4] — 2026-04-11
 
 ### Fixed

--- a/host/auto_update.py
+++ b/host/auto_update.py
@@ -23,11 +23,17 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import subprocess
+import sys
 from typing import Callable
 
 from . import config
 
 log = logging.getLogger(__name__)
+
+# Issue #534: Windows — suppress the transient cmd.exe flash when we spawn
+# `git fetch` and `git rev-list` from the scheduled loop.  No-op on Linux.
+_NO_WINDOW = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 async def _noop_route(_jid: str, _text: str) -> None:  # pragma: no cover - trivial
@@ -47,6 +53,7 @@ async def _git_is_behind(cwd: str, branch: str) -> bool:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
         cwd=cwd,
+        creationflags=_NO_WINDOW,
     )
     try:
         await asyncio.wait_for(fetch_proc.communicate(), timeout=60.0)
@@ -67,6 +74,7 @@ async def _git_is_behind(cwd: str, branch: str) -> bool:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=cwd,
+        creationflags=_NO_WINDOW,
     )
     try:
         rl_out, _ = await asyncio.wait_for(rl_proc.communicate(), timeout=30.0)

--- a/host/ipc_watcher.py
+++ b/host/ipc_watcher.py
@@ -4,12 +4,19 @@ import importlib
 import json
 import logging
 import os
+import subprocess as _subprocess
 import sys as _sys
 import pathlib as _pathlib
 import time
 import uuid
 from pathlib import Path
 from typing import Callable, Awaitable
+
+# Issue #534: Windows — pass CREATE_NO_WINDOW to every spawned subprocess so
+# git.exe, python.exe (pytest), pip.exe, claude.exe etc. do NOT flash a
+# transient console window onto the user's desktop.  On non-Windows this is 0,
+# which is a no-op when OR'd into creationflags.
+_NO_WINDOW = _subprocess.CREATE_NO_WINDOW if _sys.platform == "win32" else 0
 
 from . import config, db
 from .group_folder import is_valid_group_folder
@@ -950,6 +957,7 @@ async def _run_start_remote_control(jid: str, sender: str, route_fn: Callable) -
             stderr=_stderr_fh,
             cwd=cwd,
             start_new_session=True,
+            creationflags=_NO_WINDOW,
         )
     except Exception as exc:
         log.error("remote_control: spawn failed: %s", exc)
@@ -1026,6 +1034,7 @@ async def _run_self_update(jid: str, route_fn: Callable) -> None:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             cwd=cwd,
+            creationflags=_NO_WINDOW,
         )
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=60.0)
@@ -1073,6 +1082,7 @@ async def _run_self_update(jid: str, route_fn: Callable) -> None:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
+                creationflags=_NO_WINDOW,
             )
             _rev_stdout, _ = await _rev_proc.communicate()
             _pre_pull_sha = _rev_stdout.decode("utf-8", errors="replace").strip()
@@ -1088,6 +1098,7 @@ async def _run_self_update(jid: str, route_fn: Callable) -> None:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=cwd,
+                creationflags=_NO_WINDOW,
             )
             try:
                 # Hard cap: 10 minutes for the gate suite.
@@ -1116,6 +1127,7 @@ async def _run_self_update(jid: str, route_fn: Callable) -> None:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.STDOUT,
                     cwd=cwd,
+                    creationflags=_NO_WINDOW,
                 )
                 try:
                     await asyncio.wait_for(rb_proc.communicate(), timeout=30.0)
@@ -1143,6 +1155,7 @@ async def _run_self_update(jid: str, route_fn: Callable) -> None:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=cwd,
+                creationflags=_NO_WINDOW,
             )
             try:
                 pip_out, _ = await asyncio.wait_for(pip_proc.communicate(), timeout=120.0)


### PR DESCRIPTION
Closes #534

## Summary

Windows flashed a transient \`cmd.exe\` / \`console\` window every time the host spawned a child process via \`ipc_watcher._run_self_update\` or the new \`auto_update_loop\`. Operator saw it visibly after #530 rolled out in production with \`AUTO_UPDATE_ENABLED=true\` (one spawn per hour for \`git fetch\`, more when an update actually runs).

## Root cause

\`host/container_runner.py\` and \`host/dashboard.py\` already define a \`_NO_WINDOW\` constant and thread \`creationflags=_NO_WINDOW\` through every \`subprocess\`/\`asyncio.create_subprocess_exec\` call. But \`host/ipc_watcher.py\` (6 call sites — the pre-existing \`claude remote-control\` spawn, plus the 5 new #530 call sites: git pull, git rev-parse HEAD@{1}, pytest gate, git reset --hard, pip install) and the new \`host/auto_update.py\` (git fetch, git rev-list) never got the treatment.

## Fix

Same pattern as the other two files:

\`\`\`python
import subprocess as _subprocess
import sys as _sys
_NO_WINDOW = _subprocess.CREATE_NO_WINDOW if _sys.platform == \"win32\" else 0
\`\`\`

Then \`creationflags=_NO_WINDOW\` on every \`create_subprocess_exec\` call in both files. On Linux the constant is 0, which is a no-op when OR'd into creationflags.

## Test plan

- [x] \`pytest tests/test_self_update_test_gate.py -q\` → 3 passed (confirms asyncio accepts \`creationflags\` and the rollback path still works).
- [ ] Post-merge on Windows: watch \`pm2 logs evoclaw\` during one full \`auto_update_loop\` iteration — no console window should flash. Trigger a manual IPC \`self_update\` as well (via operator agent) and confirm silent.
- [ ] Linux: no behaviour change (CREATE_NO_WINDOW doesn't exist, \`_NO_WINDOW\` is 0).