### PR TITLE
fix(telegram): watchdog retries indefinitely with backoff after reconnect failure (#536)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.27.6] — 2026-04-14
+
+### Fixed
+- **Telegram watchdog permanently dies after 5 failed reconnect attempts.** When the staleness watchdog in `host/channels/telegram_channel.py:_poll_watchdog` detected stale polling and attempted to reconnect, a transient network outage (e.g. DNS failure) would cause `connect()` to exhaust its 5-attempt retry limit and raise. The watchdog caught the exception, logged it, then **returned** — permanently killing the watchdog task. No new reconnect would ever be attempted, leaving the bot unreachable until a manual `pm2 restart`. Fixed by replacing the single-shot `connect()` call with an indefinite retry loop using exponential backoff (60s → 120s → ... cap at 900s). Conflict and auth-failure exceptions still exit immediately (unrecoverable). (#536)
+
+### Technical Details
+- **Modified Files**: `host/channels/telegram_channel.py` (`_poll_watchdog` method)
+- **Breaking Changes**: None. The watchdog now survives network outages instead of permanently dying. Existing behaviour for Conflict/auth errors is unchanged (immediate exit with CRITICAL log).
+
 ## [1.27.5] — 2026-04-11
 
 ### Fixed

--- a/host/channels/telegram_channel.py
+++ b/host/channels/telegram_channel.py
@@ -251,6 +251,12 @@ class TelegramChannel:
         delivering updates.  In a healthy group, messages arrive regularly; in
         quiet groups the watchdog is a safety net that only fires after 5 full
         minutes of silence.
+
+        Issue #536 fix: when connect() fails (e.g. network is down), the
+        watchdog must NOT exit permanently.  Instead it retries with
+        exponential backoff (60s → 120s → ... cap at 900s) until connect()
+        succeeds or the app is shut down.  Only Conflict and auth-failure
+        exceptions are fatal — those cannot be recovered by waiting.
         """
         log.debug("Telegram poll watchdog started (threshold=%ds)", _POLL_SILENCE_THRESHOLD_S)
         while self._app is not None and self._app.running:
@@ -268,12 +274,46 @@ class TelegramChannel:
                     await self.disconnect()
                 except Exception as _disc_exc:
                     log.warning("Telegram watchdog: disconnect failed: %s", _disc_exc)
-                try:
-                    await self.connect()
-                except Exception as _conn_exc:
-                    log.error("Telegram watchdog: reconnect failed: %s", _conn_exc)
-                # connect() starts a new watchdog task; this one exits.
-                return
+
+                # Retry connect() with exponential backoff until it succeeds.
+                # Only bail on Conflict or auth failures (unrecoverable).
+                _wd_backoff = 60
+                _WD_BACKOFF_CAP = 900  # 15 minutes
+                while True:
+                    if self._app is None:
+                        log.debug("Telegram watchdog: app is None, exiting")
+                        return
+                    try:
+                        await self.connect()
+                        # connect() succeeded and started a new watchdog → this
+                        # one can exit cleanly.
+                        log.info("Telegram watchdog: reconnect succeeded after backoff")
+                        return
+                    except Exception as _conn_exc:
+                        _exc_str = str(_conn_exc).lower()
+                        # Conflict / auth failures are unrecoverable — don't
+                        # burn CPU retrying a revoked token or a duplicate bot.
+                        if any(kw in _exc_str for kw in (
+                            "conflict", "unauthorized", "invalid token",
+                            "forbidden", "bot was kicked",
+                        )):
+                            log.critical(
+                                "Telegram watchdog: unrecoverable error — %s: %s. "
+                                "Watchdog exiting. Fix the issue and restart.",
+                                type(_conn_exc).__name__, _conn_exc,
+                            )
+                            return
+                        log.warning(
+                            "Telegram watchdog: reconnect failed (%s: %s) — "
+                            "retrying in %ds",
+                            type(_conn_exc).__name__, _conn_exc, _wd_backoff,
+                        )
+                        # Wait with backoff; bail early if app is shut down.
+                        try:
+                            await asyncio.sleep(_wd_backoff)
+                        except asyncio.CancelledError:
+                            return
+                        _wd_backoff = min(_wd_backoff * 2, _WD_BACKOFF_CAP)
         log.debug("Telegram poll watchdog exiting (app stopped)")
 
     # Telegram hard limit is 4096 UTF-16 code units; use 4000 for a safety margin.


### PR DESCRIPTION
Closes #536

## Summary

The Telegram polling staleness watchdog permanently died after a single failed reconnect cycle, leaving the bot unreachable until manual `pm2 restart`. Observed 2026-04-13: a ~1 minute DNS outage caused `connect()` to exhaust its 5-attempt limit, then the watchdog returned and never retried. Telegram polling stayed dead for 2+ days.

## Fix

Replace the single-shot `connect()` call in `_poll_watchdog` with an indefinite retry loop using exponential backoff:

```
connect() fails → wait 60s → retry
connect() fails → wait 120s → retry
connect() fails → wait 240s → retry
...
connect() fails → wait 900s (cap) → retry
connect() succeeds → new watchdog starts → old one exits cleanly
```

Conflict and auth-failure exceptions (`"unauthorized"`, `"invalid token"`, `"forbidden"`, `"bot was kicked"`, `"conflict"`) still exit immediately — retrying those is pointless.

## Changes

- `host/channels/telegram_channel.py` — `_poll_watchdog()`: wrapped the reconnect in a `while True` loop with exponential backoff (60s → 900s cap). Fatal exceptions break out immediately.
- `docs/CHANGELOG.md` — `[1.27.6]` under `### Fixed`.

## Test plan

- [x] Import check: `python -c "import host.channels.telegram_channel"` OK
- [x] Manual verification: watchdog triggered at 09:14:51 today (301s silence), reconnected successfully in ~5s
- [ ] Post-merge: simulate network outage (disconnect Wi-Fi for 6+ min), confirm watchdog retries and recovers when network returns — without manual restart