### PR TITLE
fix(container): remove HEALTHCHECK that caused OOM by spawning second Python (#539)

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -149,13 +149,15 @@ ENV PYTHONUNBUFFERED=1
 ENV LANG=C.UTF-8
 ENV NODE_ENV=production
 
-# ── Health check (p17b) ───────────────────────────────────────────────────────
-# Verify that the agent module and its critical dependencies are importable.
-# Previously this only checked python3 exits 0, which passes even with a
-# broken install.  Now it imports the key third-party packages so a broken
-# layer is caught before a real run is attempted.
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python3 -c "import json, pathlib, anthropic, openai; import google.genai; print('ok')"
+# ── Health check REMOVED (Issue #539) ────────────────────────────────────────
+# The previous HEALTHCHECK spawned a second Python process every 30s that
+# imported all three LLM SDKs (anthropic + openai + google.genai), adding
+# ~80-100 MB to the cgroup.  When this coincided with the agent's LLM API
+# call, the combined memory exceeded the cgroup limit → OOM (exit 137).
+# Measured: agent steady-state 66 MiB → 147 MiB when healthcheck fires.
+# Agent containers are run-to-completion (seconds to minutes), not long-lived
+# services — a periodic healthcheck is meaningless for this lifecycle.
+HEALTHCHECK NONE
 
 # BUG-19B-08 FIX: declare SIGTERM as the stop signal so that `docker stop`
 # delivers SIGTERM to PID 1 (the bash entrypoint).  Without this instruction

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.27.7] — 2026-04-16
+
+### Fixed
+- **Container OOM (exit 137) caused by HEALTHCHECK spawning a second Python process.** The Dockerfile HEALTHCHECK ran `python3 -c "import anthropic, openai; import google.genai"` every 30 seconds inside the same cgroup as the agent. Each healthcheck process loaded all three LLM SDKs (~80-100 MB), and when it coincided with the agent's LLM API call, combined memory exceeded the cgroup limit. Measured: agent steady-state 66 MiB → 147 MiB when healthcheck fires. Replaced with `HEALTHCHECK NONE` — agent containers are run-to-completion (seconds to minutes), not long-lived services. (#539)
+
+### Technical Details
+- **Modified Files**: `container/Dockerfile`
+- **Breaking Changes**: None. Requires `docker build -t evoclaw-agent:latest container/` to rebuild the image.
+- **Root cause evidence**: 4 historical OOM events all correlated with LLM API calls (the timing window where healthcheck + API call overlap). Retries succeeded because healthcheck happened to not be running during the retry.
+
 ## [1.27.6] — 2026-04-14
 
 ### Fixed


### PR DESCRIPTION
Closes #539

## Root cause

The Dockerfile HEALTHCHECK spawned a second Python process every 30s inside the same cgroup, importing all three LLM SDKs (+80-100 MB). When it coincided with the agent's LLM API call, combined memory exceeded the cgroup limit -> exit 137.

## Evidence

```
T+21s: 65.91 MiB  (agent steady state)
T+24s: 147.00 MiB (healthcheck fires, +81 MB)
T+27s: 66.51 MiB  (healthcheck exits)
```

All 4 historical OOMs correlated with LLM call timing. Retries succeeded because healthcheck was not running.

## Fix

`HEALTHCHECK NONE` — agent containers are run-to-completion, not long-lived services.

## Test plan

- [x] Measured: no memory spike without healthcheck (steady 66 MiB)
- [ ] Post-merge: `docker build -t evoclaw-agent:latest container/` and verify no more exit 137 under normal workloads