### PR TITLE
fix(telegram): watchdog false-positive kills polling in quiet groups (#541)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.27.9] — 2026-04-20
+
+### Fixed
+- **Telegram watchdog false-positive kills polling every 5 minutes in quiet groups.** `_last_poll_activity` was only updated on text message receipt, not on successful `getUpdates` calls. In quiet groups with no messages, the 300-second threshold was always hit, triggering a reconnect that often failed — leaving the bot permanently unreachable. Raised threshold to 1800s (30 min) and added a `TypeHandler(Update, ...)` at group=-1 that updates activity on ANY update type. (#541)
+
+### Technical Details
+- **Modified Files**: `host/channels/telegram_channel.py`
+- **Breaking Changes**: None.
+
 ## [1.27.8] — 2026-04-16
 
 ### Fixed

--- a/host/channels/telegram_channel.py
+++ b/host/channels/telegram_channel.py
@@ -16,7 +16,14 @@ log = logging.getLogger(__name__)
 # warning and attempt to reconnect.  Distinct from the startup retry logic —
 # this catches cases where polling is running but Telegram stops delivering
 # updates (e.g. a silent TCP connection hang).
-_POLL_SILENCE_THRESHOLD_S = 300  # 5 minutes
+# Issue #541 follow-up: 300s (5 min) was far too aggressive — in quiet groups
+# with no messages, the watchdog triggered a false-positive reconnect every
+# 5 minutes, which then killed polling entirely.  Raised to 1800s (30 min).
+# The real staleness signal is "getUpdates returns errors", not "no messages
+# received".  The catch-all TypeHandler(Update, ...) added below updates
+# _last_poll_activity on ANY update type (not just text), which further
+# reduces false positives.
+_POLL_SILENCE_THRESHOLD_S = 1800  # 30 minutes
 
 
 class TelegramChannel:
@@ -180,6 +187,16 @@ class TelegramChannel:
                         handle_non_text,
                     )
                 )
+                # Issue #541: catch-all handler to update _last_poll_activity
+                # on ANY update type (callback queries, reactions, edits, etc.)
+                # so the staleness watchdog doesn't false-positive in quiet groups.
+                from telegram.ext import TypeHandler as _TypeHandler
+
+                async def _activity_tracker(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+                    self._last_poll_activity = time.time()
+
+                self._app.add_handler(_TypeHandler(Update, _activity_tracker), group=-1)
+
                 await self._app.initialize()
                 await self._app.start()
                 # drop_pending_updates=True: flush all messages that accumulated


### PR DESCRIPTION
Refs #541

## Problem

The staleness watchdog (_POLL_SILENCE_THRESHOLD_S=300) triggered every 5 minutes in quiet groups with no messages, disconnecting healthy polling and often failing to reconnect — leaving the bot permanently unreachable.

Root cause: _last_poll_activity was only updated on TEXT message receipt, not on successful getUpdates. In quiet groups, the timestamp never advanced.

## Fix

1. Raise threshold from 300s to 1800s (30 min)
2. Add TypeHandler(Update, _activity_tracker) at group=-1 that updates _last_poll_activity on ANY update type

## Verification

After this fix, evoclaw ran 2+ hours without watchdog false-positive (previously died every 5 min in quiet groups).

## Test plan

- [x] evoclaw ran 2h+ without watchdog triggering in quiet group
- [x] Syntax check passes
- [ ] Post-merge: confirm watchdog still catches real polling failures (simulate by blocking api.telegram.org)