### PR TITLE
fix(agent): memory fragmentation OOM at turn=7 + comprehensive fixes (#541)

### DIFF
--- a/container/agent-runner/_constants.py
+++ b/container/agent-runner/_constants.py
@@ -24,7 +24,7 @@ _input_chat_jid: str = ""
 
 # History / tool-result size limits (P9A)
 _MAX_TOOL_RESULT_CHARS = 4000  # ~4KB per tool result
-_MAX_HISTORY_MESSAGES = 40     # max messages in history
+_MAX_HISTORY_MESSAGES = 20     # max messages in history (was 40; #541 OOM at turn=7 with 40 msgs/59KB)
 
 # BUG-P21-1 / BUG-P21-4: Module-level action-claim regex with stricter structure.
 # The old pattern matched single Chinese characters like 已/完成/成功 as standalone

--- a/container/agent-runner/_loop_openai.py
+++ b/container/agent-runner/_loop_openai.py
@@ -40,7 +40,27 @@ def _log_rss(prefix: str, **extra) -> None:
 # enough — a single tool_result can be 8 KB, so 40 messages = 320 KB best case
 # but easily 1+ MB if tool outputs are at cap. Add a byte cap that runs BEFORE
 # each LLM call.
-_HISTORY_BYTE_BUDGET = 256 * 1024  # 256 KB of serialized history
+_HISTORY_BYTE_BUDGET = 64 * 1024  # 64 KB — tightened from 256 KB after OOM at 59KB/40msgs
+
+
+# ── Issue #541: reclaim fragmented memory before LLM calls ────────────────────
+# After multiple turns of subprocess fork+exec + JSON alloc/dealloc, Python's
+# pymalloc arenas fragment.  VmPeak grows to 300+ MB even though RSS is ~100 MB.
+# The next large allocation (httpx TLS buffer, streaming response) can't reuse
+# freed arenas and triggers a new mmap() that pushes the cgroup past its limit.
+#
+# gc.collect() reclaims Python objects; malloc_trim() (glibc) returns freed pages
+# to the OS so the cgroup memory counter drops.  Together they close the gap
+# between VmPeak and RSS.
+def _reclaim_memory() -> None:
+    """Force GC + return freed pages to OS to reduce cgroup memory pressure."""
+    gc.collect()
+    try:
+        import ctypes
+        _libc = ctypes.CDLL("libc.so.6")
+        _libc.malloc_trim(0)
+    except Exception:
+        pass  # Non-glibc or non-Linux — skip silently
 
 
 def _trim_history_to_byte_budget(history: list, budget: int = _HISTORY_BYTE_BUDGET) -> tuple:
@@ -269,9 +289,7 @@ def run_agent_openai(client_holder, system_instruction: str, user_message: str, 
     ])
 
     for n in range(MAX_ITER):
-        # MEMORY-OOM-FIX: force GC every 5 turns to reclaim accumulated objects.
-        if n > 0 and n % 5 == 0:
-            gc.collect()
+        # (gc+malloc_trim moved to _reclaim_memory() call before each LLM call)
         # Escalate to "required" when model has been avoiding tools (Fix #169).
         # tool_choice="required" is enforced at the API level — the model CANNOT
         # return a text-only response, it MUST make a tool call.
@@ -297,6 +315,9 @@ def run_agent_openai(client_holder, system_instruction: str, user_message: str, 
             _tool_choice = "auto"
         if _no_tool_turns > 0:
             _log("⚠️ FORCE-TOOL", f"no_tool_turns={_no_tool_turns} — escalating tool_choice to 'required'")
+
+        # Issue #541 — reclaim fragmented memory before building the request.
+        _reclaim_memory()
 
         # Issue #541 — byte-cap history before sending to bound request size.
         history, _hist_orig_b, _hist_kept_b = _trim_history_to_byte_budget(history)
@@ -616,6 +637,9 @@ def run_agent_openai(client_holder, system_instruction: str, user_message: str, 
             except Exception as _tool_exc:
                 result = f"[Tool error: {_tool_exc}]"
                 _log("❌ TOOL-EXC", f"Tool {tc.function.name} raised exception: {_tool_exc}")
+            # Issue #541: reclaim subprocess memory immediately after tool call
+            _reclaim_memory()
+            _log_rss(f"post-tool {tc.function.name}")
             # Truncate large tool results before adding to history
             result_str = str(result)
             if len(result_str) > _MAX_TOOL_RESULT_CHARS:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ### Fixed
 - **Telegram watchdog false-positive kills polling every 5 minutes in quiet groups.** `_last_poll_activity` was only updated on text message receipt, not on successful `getUpdates` calls. In quiet groups with no messages, the 300-second threshold was always hit, triggering a reconnect that often failed — leaving the bot permanently unreachable. Raised threshold to 1800s (30 min) and added a `TypeHandler(Update, ...)` at group=-1 that updates activity on ANY update type. (#541)
+- **Container OOM at turn=7 despite streaming fix.** Instrumentation captured: `pre-LLM turn=7 rss=106MB peak=312MB hist=59KB/40msgs` → OOM at 768MB limit. Root cause: Python memory fragmentation from 7 turns of subprocess fork/exec — pymalloc arenas fragment, VmPeak grows to 312MB, next large allocation triggers new `mmap()` that pushes cgroup past limit. Three fixes: (1) `_reclaim_memory()` (gc.collect + glibc malloc_trim) before every LLM call and after every tool call — returns freed pages to OS, reduces cgroup counter; (2) `_MAX_HISTORY_MESSAGES` reduced from 40 to 20; (3) `_HISTORY_BYTE_BUDGET` reduced from 256KB to 64KB. Also increased container_runner stderr capture from 5 to 50 lines to preserve RSS instrumentation data on OOM. (#541)
 
 ### Technical Details
-- **Modified Files**: `host/channels/telegram_channel.py`
-- **Breaking Changes**: None.
+- **Modified Files**: `host/channels/telegram_channel.py`, `container/agent-runner/_loop_openai.py`, `container/agent-runner/_constants.py`, `host/container_runner.py`
+- **Image rebuild required**: `docker build -t evoclaw-agent:latest container/`
+- **Breaking Changes**: `_MAX_HISTORY_MESSAGES` reduced from 40 to 20 — agents will have less context from prior turns. This trades context depth for stability.
 
 ## [1.27.8] — 2026-04-16
 

--- a/host/container_runner.py
+++ b/host/container_runner.py
@@ -861,9 +861,9 @@ async def run_container_agent(
             _stderr_split_lines = stderr.splitlines() if stderr else []
             if _stderr_split_lines:
                 log.warning(
-                    "Container %s stderr (last 5 lines):\n%s",
+                    "Container %s stderr (last 50 lines):\n%s",
                     container_name,
-                    "\n".join(_redact_secrets(l) for l in _stderr_split_lines[-5:])
+                    "\n".join(_redact_secrets(l) for l in _stderr_split_lines[-50:])
                 )
             log.warning("No valid output markers in container stdout")
             response_ms = int((time.time() - t0) * 1000)


### PR DESCRIPTION
Refs #541

## Evidence

Instrumentation from #542 captured the first data-backed OOM:
\`\`\`
pre-LLM turn=7 rss=106MB peak=312MB hist=59KB/40msgs → OOM at 768MB
\`\`\`
Docker stats: steady 87-88 MiB across 21 samples. Container died in 4s between last sample and OOM.

## Root cause

After 7 turns of subprocess fork/exec + JSON alloc/dealloc, Python's pymalloc arenas fragment. VmPeak grows to 312MB; RSS drops to 106MB as objects are freed, but **freed pages are not returned to the OS**. Next large allocation (httpx TLS buffer during streaming LLM call) triggers a new \`mmap()\` for pages → cgroup memory.current exceeds 768MB → SIGKILL.

## Fixes

**Agent side (requires image rebuild):**
- \`_reclaim_memory()\` = \`gc.collect()\` + glibc \`malloc_trim(0)\`, called before every LLM call and after every tool call. \`malloc_trim\` returns freed pages to OS — closes the gap between VmPeak and RSS.
- \`_MAX_HISTORY_MESSAGES\`: 40 → 20
- \`_HISTORY_BYTE_BUDGET\`: 256KB → 64KB
- \`_log_rss\` added after each tool call to catch which tool spikes

**Host side:**
- \`container_runner.py\` stderr capture: 5 → 50 lines (preserve RSS instrumentation on OOM)
- \`telegram_channel.py\` watchdog: 300s → 1800s + TypeHandler catch-all (fixes false-positive polling kills in quiet groups)

## Test plan

- [x] Syntax check passes
- [x] Earlier manual test (5 turns, simple prompt): RSS stayed at 103MB — streaming alone was sufficient for simple cases
- [ ] Post-merge: rebuild image, trigger 7+ turn conversation, confirm no OOM and \`post-tool\` RSS logs stay bounded