### PR TITLE
fix(agent): stream consume O(N) + hard caps to prevent OOM (#541)

### DIFF
--- a/container/agent-runner/_loop_openai.py
+++ b/container/agent-runner/_loop_openai.py
@@ -182,16 +182,29 @@ class _StreamedResponse:
         self.choices = choices
 
 
+# Hard caps for stream consumption (Issue #541: OOM at turn=4 during streaming)
+_STREAM_MAX_TOTAL_BYTES = 1 * 1024 * 1024   # 1 MB hard cap across all chunks
+_STREAM_MAX_ARGS_BYTES_PER_TOOL = 32 * 1024 # 32 KB per tool_call.arguments
+
+
 def _consume_stream(stream) -> _StreamedResponse:
     """Drain a streaming chat.completions response into a non-streaming-shaped object.
 
-    Memory profile: holds only the accumulated text + tool-call args, never the
-    full response payload + pydantic models simultaneously.
+    Memory profile:
+    - content accumulates into a list (O(N) via "".join at the end)
+    - tool_call.arguments accumulates into per-slot lists (O(N) via "".join)
+    - Hard cap on total bytes (1 MB) — fail-fast if model runs amok
+    - Hard cap per tool_call arguments (32 KB) — truncate absurd payloads
+
+    Previously used `slot["arguments"] += chunk` which is O(N²) for large
+    args and can trigger mmap()-driven cgroup OOM on models that stream
+    huge tool_call.arguments payloads.
     """
-    content_parts = []
-    # idx -> {id, type, name, arguments}
+    content_parts: list = []
+    # idx -> {id, type, name, args_parts: list[str], args_bytes: int, truncated: bool}
     tool_calls_acc: dict = {}
     finish_reason = None
+    total_bytes = 0
     for chunk in stream:
         if not chunk.choices:
             continue
@@ -199,11 +212,16 @@ def _consume_stream(stream) -> _StreamedResponse:
         delta = choice.delta
         if delta is not None:
             if delta.content:
-                content_parts.append(delta.content)
+                c = delta.content
+                content_parts.append(c)
+                total_bytes += len(c)
             if delta.tool_calls:
                 for tc in delta.tool_calls:
                     idx = tc.index
-                    slot = tool_calls_acc.setdefault(idx, {"id": "", "type": "function", "name": "", "arguments": ""})
+                    slot = tool_calls_acc.setdefault(idx, {
+                        "id": "", "type": "function", "name": "",
+                        "args_parts": [], "args_bytes": 0, "truncated": False,
+                    })
                     if tc.id:
                         slot["id"] = tc.id
                     if tc.type:
@@ -212,20 +230,44 @@ def _consume_stream(stream) -> _StreamedResponse:
                         if tc.function.name:
                             slot["name"] = tc.function.name
                         if tc.function.arguments:
-                            slot["arguments"] += tc.function.arguments
+                            a = tc.function.arguments
+                            if slot["args_bytes"] + len(a) <= _STREAM_MAX_ARGS_BYTES_PER_TOOL:
+                                slot["args_parts"].append(a)
+                                slot["args_bytes"] += len(a)
+                                total_bytes += len(a)
+                            elif not slot["truncated"]:
+                                slot["truncated"] = True
+                                # Fill remaining budget then stop appending for this tool
+                                remaining = _STREAM_MAX_ARGS_BYTES_PER_TOOL - slot["args_bytes"]
+                                if remaining > 0:
+                                    slot["args_parts"].append(a[:remaining])
+                                    slot["args_bytes"] += remaining
+                                    total_bytes += remaining
         if choice.finish_reason:
             finish_reason = choice.finish_reason
 
+        # Total stream cap — if the server is streaming a runaway response,
+        # stop here before we OOM.
+        if total_bytes > _STREAM_MAX_TOTAL_BYTES:
+            _log("⚠️ STREAM-CAP", f"total_bytes={total_bytes} exceeded cap — truncating stream")
+            finish_reason = finish_reason or "length"
+            break
+
     content = "".join(content_parts) if content_parts else None
+    del content_parts  # release the list immediately
     if tool_calls_acc:
         tcs = []
         for idx in sorted(tool_calls_acc.keys()):
             slot = tool_calls_acc[idx]
+            args_joined = "".join(slot["args_parts"])
+            if slot["truncated"]:
+                _log("⚠️ TOOL-ARGS-CAP", f"tool={slot['name']} args truncated at {slot['args_bytes']}B")
             tcs.append(_StreamedToolCall(
                 id_=slot["id"],
                 type_=slot["type"],
-                function=_StreamedFunction(name=slot["name"], arguments=slot["arguments"]),
+                function=_StreamedFunction(name=slot["name"], arguments=args_joined),
             ))
+        del tool_calls_acc  # release the dict
     else:
         tcs = None
     msg = _StreamedMessage(content=content, tool_calls=tcs)
@@ -337,7 +379,7 @@ def run_agent_openai(client_holder, system_instruction: str, user_message: str, 
                 tools=OPENAI_TOOL_DECLARATIONS,
                 tool_choice=tool_choice,
                 temperature=0.2 if _is_qwen else 0.3,
-                max_tokens=4096,
+                max_tokens=2048,  # #541: 4096 allowed runaway responses that OOM'd the container
             )
             if stream:
                 kwargs["stream"] = True

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.27.10] — 2026-04-20
+
+### Fixed
+- **Post-#541 OOM still triggers during streaming LLM call (turn=4).** Instrumentation (#541) captured the exact sequence: `turn=2/3 rss=104-105MB peak=312MB` succeeded, but `turn=4 pre-LLM rss=105MB peak=312MB` → OOM during the streaming call itself. RSS/history/VmPeak all bounded; the spike is INSIDE `_consume_stream()`. Three root causes:
+  1. **`slot["arguments"] += chunk` is O(N²)** — large tool_call.arguments (e.g., model echoing a fetched URL content) triggers quadratic string allocation that pushes cgroup past limit.
+  2. **No hard cap on streamed total bytes** — a runaway model (stuck in a WebFetch loop, as observed) can stream unboundedly.
+  3. **`max_tokens=4096` too permissive** for 120B models via NIM.
+
+  Fixes: rewrote `_consume_stream()` to use `list` + `"".join()` (O(N)); added `_STREAM_MAX_TOTAL_BYTES=1MB` and `_STREAM_MAX_ARGS_BYTES_PER_TOOL=32KB` hard caps with graceful truncation; reduced `max_tokens` from 4096 to 2048. (#541)
+
+### Technical Details
+- **Modified Files**: `container/agent-runner/_loop_openai.py`
+- **Image rebuild required**: `docker build -t evoclaw-agent:latest container/`
+- **Breaking Changes**: None at API level. Truncated streams log `⚠️ STREAM-CAP` or `⚠️ TOOL-ARGS-CAP` for visibility.
+
 ## [1.27.9] — 2026-04-20
 
 ### Fixed


### PR DESCRIPTION
Refs #541

## Evidence

After #544 added \`_reclaim_memory()\` + history caps, OOM moved from turn=7 to turn=4 — closer but still OOMing. Instrumentation captured:

\`\`\`
turn=2: pre rss=104 → post rss=104 peak=312  hist=32KB  ✓
turn=3: pre rss=105 → post rss=105 peak=312  hist=35KB  ✓
turn=4: pre rss=105 peak=312 hist=40KB/20msgs → OOM DURING streaming
\`\`\`

RSS/peak/history all bounded. The spike is INSIDE \`_consume_stream()\`.

## Root causes

1. **\`slot[\"arguments\"] += chunk\` is O(N²)** — a runaway model (stuck in a WebFetch loop, observed in the OOM log) streams large \`tool_call.arguments\` and each chunk triggers a full-string copy.
2. **No total-stream cap** — runaway response can grow unbounded.
3. **\`max_tokens=4096\`** is too permissive for 120B models via NIM.

## Fixes

- Rewrote \`_consume_stream()\` to append chunks into a list and \`\"\".join\` once at the end (O(N)).
- Hard caps with graceful truncation:
  - \`_STREAM_MAX_TOTAL_BYTES = 1 MB\`
  - \`_STREAM_MAX_ARGS_BYTES_PER_TOOL = 32 KB\`
- \`max_tokens\` 4096 → 2048.
- Log markers \`⚠️ STREAM-CAP\` and \`⚠️ TOOL-ARGS-CAP\` when caps trigger.

## Test plan

- [x] Syntax check passes
- [ ] Post-merge: rebuild image, trigger multi-turn conversation with WebFetch, confirm no OOM and caps are logged if model runs amok