### PR TITLE
feat(agent): chunked WebFetch with offset/max_chars (#546)

### DIFF
--- a/container/agent-runner/_registry.py
+++ b/container/agent-runner/_registry.py
@@ -257,11 +257,13 @@ TOOL_DECLARATIONS = [] if not _GOOGLE_AVAILABLE or types is None else [
     ),
     types.FunctionDeclaration(
         name="WebFetch",
-        description="Fetch content from a URL and return it as plain text. Useful for reading docs, news, GitHub READMEs.",
+        description="Fetch content from a URL and return it as plain text (chunked). Each call returns up to ~3500 chars starting at `offset`. If the response footer says `[chunk: chars X-Y of total Z]` and Y < Z, call again with offset=Y to get the next chunk.",
         parameters=types.Schema(
             type=types.Type.OBJECT,
             properties={
                 "url": types.Schema(type=types.Type.STRING, description="The URL to fetch"),
+                "offset": types.Schema(type=types.Type.INTEGER, description="Starting character offset (default 0). Use the value from the previous response's footer to get the next chunk."),
+                "max_chars": types.Schema(type=types.Type.INTEGER, description="Max characters per chunk (default 3500, max 8000)."),
             },
             required=["url"],
         ),
@@ -372,7 +374,7 @@ OPENAI_TOOL_DECLARATIONS = [
     {"type": "function", "function": {"name": "mcp__evoclaw__resume_task", "description": "Resume a previously paused scheduled task.", "parameters": {"type": "object", "properties": {"task_id": {"type": "string", "description": "The task ID to resume"}}, "required": ["task_id"]}}},
     {"type": "function", "function": {"name": "Glob", "description": "Find files matching a glob pattern (supports ** recursive).", "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}}, "required": ["pattern"]}}},
     {"type": "function", "function": {"name": "Grep", "description": "Search file contents with regex. Returns filename:line:content.", "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}, "include": {"type": "string"}}, "required": ["pattern"]}}},
-    {"type": "function", "function": {"name": "WebFetch", "description": "Fetch a URL and return its content as plain text.", "parameters": {"type": "object", "properties": {"url": {"type": "string"}}, "required": ["url"]}}},
+    {"type": "function", "function": {"name": "WebFetch", "description": "Fetch a URL and return its content as plain text (chunked). Returns up to ~3500 chars starting at `offset`. If the footer reports more chars remaining, call again with offset=<end of previous chunk>.", "parameters": {"type": "object", "properties": {"url": {"type": "string"}, "offset": {"type": "integer", "description": "starting char offset, default 0"}, "max_chars": {"type": "integer", "description": "max chars per chunk, default 3500, max 8000"}}, "required": ["url"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__run_agent", "description": "Spawn a subagent in an isolated Docker container to handle a subtask. Blocks until complete (up to 300s) and returns its output.", "parameters": {"type": "object", "properties": {"prompt": {"type": "string", "description": "The task for the subagent"}, "context_mode": {"type": "string", "description": "isolated or group"}}, "required": ["prompt"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__send_file", "description": "Send a file to the user. Write the file to /workspace/group/output/ first, then call this tool.", "parameters": {"type": "object", "properties": {"chat_jid": {"type": "string", "description": "The chat JID to send the file to"}, "file_path": {"type": "string", "description": "Absolute container path to the file"}, "caption": {"type": "string", "description": "Optional caption"}}, "required": ["file_path"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__reset_group", "description": "Clear the failure counter for a group, unfreezing it if it was locked in cooldown. Use when a group is stuck and not responding.", "parameters": {"type": "object", "properties": {"jid": {"type": "string", "description": "The JID of the group to reset, e.g. tg:8259652816"}}, "required": ["jid"]}}},
@@ -397,7 +399,7 @@ CLAUDE_TOOL_DECLARATIONS = [
     {"name": "mcp__evoclaw__resume_task", "description": "Resume a previously paused scheduled task.", "input_schema": {"type": "object", "properties": {"task_id": {"type": "string", "description": "The task ID to resume"}}, "required": ["task_id"]}},
     {"name": "Glob", "description": "Find files matching a glob pattern (supports ** recursive).", "input_schema": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}}, "required": ["pattern"]}},
     {"name": "Grep", "description": "Search file contents with regex. Returns filename:line:content.", "input_schema": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}, "include": {"type": "string"}}, "required": ["pattern"]}},
-    {"name": "WebFetch", "description": "Fetch a URL and return its content as plain text.", "input_schema": {"type": "object", "properties": {"url": {"type": "string"}}, "required": ["url"]}},
+    {"name": "WebFetch", "description": "Fetch a URL and return its content as plain text (chunked). Returns up to ~3500 chars starting at `offset`. If the footer reports more chars remaining, call again with offset=<end of previous chunk>.", "input_schema": {"type": "object", "properties": {"url": {"type": "string"}, "offset": {"type": "integer", "description": "starting char offset, default 0"}, "max_chars": {"type": "integer", "description": "max chars per chunk, default 3500, max 8000"}}, "required": ["url"]}},
     {"name": "mcp__evoclaw__run_agent", "description": "Spawn a subagent in an isolated Docker container to handle a subtask. Blocks until complete (up to 300s) and returns its output.", "input_schema": {"type": "object", "properties": {"prompt": {"type": "string", "description": "The task for the subagent"}, "context_mode": {"type": "string", "description": "isolated or group"}}, "required": ["prompt"]}},
     {"name": "mcp__evoclaw__send_file", "description": "Send a file to the user. Write the file to /workspace/group/output/ first, then call this tool.", "input_schema": {"type": "object", "properties": {"chat_jid": {"type": "string", "description": "The chat JID to send the file to"}, "file_path": {"type": "string", "description": "Absolute container path to the file"}, "caption": {"type": "string", "description": "Optional caption"}}, "required": ["file_path"]}},
     {"name": "mcp__evoclaw__reset_group", "description": "Clear the failure counter for a group, unfreezing it if it was locked in cooldown. Use when a group is stuck and not responding.", "input_schema": {"type": "object", "properties": {"jid": {"type": "string", "description": "The JID of the group to reset, e.g. tg:8259652816"}}, "required": ["jid"]}},
@@ -496,7 +498,9 @@ def _execute_tool_inner(name: str, args: dict, chat_jid: str) -> str:
         _url = args.get("url")
         if not isinstance(_url, str):
             return "Error: WebFetch requires a 'url' string argument"
-        return tool_web_fetch(_url)
+        _offset = args.get("offset", 0)
+        _max_chars = args.get("max_chars", 3500)
+        return tool_web_fetch(_url, offset=_offset, max_chars=_max_chars)
     elif name == "mcp__evoclaw__run_agent":
         _ra_prompt = args.get("prompt")
         if not isinstance(_ra_prompt, str):

--- a/container/agent-runner/_tools.py
+++ b/container/agent-runner/_tools.py
@@ -979,11 +979,27 @@ def tool_grep(pattern: str, path: str = WORKSPACE, include: str = "*") -> str:
                 pass
 
 
-def tool_web_fetch(url: str) -> str:
+def tool_web_fetch(url: str, offset: int = 0, max_chars: int = 3500) -> str:
     """
     從指定 URL 抓取網頁內容，自動將 HTML 轉換為純文字。
     適合查閱文件、新聞、GitHub README 等網頁資料。
-    結果最多回傳 50KB（文字），超過部分截斷。
+
+    Issue #541 follow-up: chunked fetch.  Each call returns at most
+    `max_chars` characters starting at `offset`.  When the document is
+    longer than the chunk, the result is suffixed with a metadata footer:
+
+        [chunk: chars 0-3500 of total 12345.
+         To get the next chunk, call: WebFetch(url, offset=3500)]
+
+    so the model can iteratively fetch the rest without hitting the
+    _MAX_TOOL_RESULT_CHARS=4000 truncation in the LLM loop.
+
+    Args:
+        url: target URL (http/https only)
+        offset: starting character offset (default 0 = beginning)
+        max_chars: max characters to return in this chunk (default 3500,
+            chosen to leave headroom under _MAX_TOOL_RESULT_CHARS=4000
+            so the chunk + footer is not further truncated)
 
     安全限制：
     - SSRF 防護：封鎖私有/迴環/雲端 metadata IP 範圍
@@ -998,6 +1014,19 @@ def tool_web_fetch(url: str) -> str:
 
     _WEB_FETCH_TEXT_LIMIT = 50 * 1024    # 50 KB returned to LLM
     _WEB_FETCH_RAW_LIMIT  = 2 * 1024 * 1024  # 2 MB raw download cap
+
+    # Validate chunk parameters defensively (LLM may pass garbage).
+    try:
+        offset = max(0, int(offset))
+    except (ValueError, TypeError):
+        offset = 0
+    try:
+        max_chars = int(max_chars)
+    except (ValueError, TypeError):
+        max_chars = 3500
+    # Hard caps: minimum 500 (so it's actually useful), maximum 8000 (so the
+    # chunk + footer fits under 8 KB, leaving room above the LLM truncation).
+    max_chars = max(500, min(8000, max_chars))
 
     # BUG-P18D-08: validate url type before passing to urlparse to prevent
     # AttributeError / TypeError when the LLM passes a non-string.
@@ -1197,9 +1226,42 @@ def tool_web_fetch(url: str) -> str:
         else:
             text = raw
 
+        # Hard upper bound on what we'll EVER serve (still 50 KB),
+        # independent of the per-chunk cap.
         if len(text) > _WEB_FETCH_TEXT_LIMIT:
-            text = text[:_WEB_FETCH_TEXT_LIMIT] + "\n\n... (content truncated at 50KB)"
-        return text or "(empty response)"
+            text = text[:_WEB_FETCH_TEXT_LIMIT]
+            _truncated_at_50k = True
+        else:
+            _truncated_at_50k = False
+
+        total_chars = len(text)
+        if total_chars == 0:
+            return "(empty response)"
+
+        # Issue #541 follow-up: chunked return.
+        if offset >= total_chars:
+            return (
+                f"(offset {offset} is past end of document; total {total_chars} chars"
+                + (" — note: hit 50KB cap" if _truncated_at_50k else "")
+                + ")"
+            )
+
+        end = min(offset + max_chars, total_chars)
+        chunk = text[offset:end]
+
+        # Footer with chunk metadata so the model knows how to continue.
+        if end < total_chars:
+            cap_note = " — note: source was 50KB-capped" if _truncated_at_50k else ""
+            footer = (
+                f"\n\n[chunk: chars {offset}-{end} of total {total_chars}{cap_note}. "
+                f"To get the next chunk, call: WebFetch(url={url!r}, offset={end})]"
+            )
+        elif offset > 0 or _truncated_at_50k:
+            cap_note = " (source was 50KB-capped)" if _truncated_at_50k else ""
+            footer = f"\n\n[chunk: chars {offset}-{end} of total {total_chars}{cap_note} — END]"
+        else:
+            footer = ""  # entire document fit in one chunk; no metadata needed
+        return chunk + footer
     except urllib.error.HTTPError as e:
         return f"HTTP {e.code} error fetching {url}: {e.reason}"
     except urllib.error.URLError as e:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.27.11] — 2026-04-21
+
+### Changed
+- **WebFetch is now chunked.** A long URL (e.g., a multi-KB GitHub raw file) was fetched up to 50 KB and then truncated to 4 KB by the LLM-loop tool-result cap (head 2 KB + tail 2 KB, middle dropped) — leaving the model unable to translate or analyse the middle. Added `offset` and `max_chars` parameters (default 3500 chars per chunk, max 8000) plus a footer telling the model exactly how to fetch the next chunk: `[chunk: chars X-Y of total Z. To get the next chunk, call: WebFetch(url=..., offset=Y)]`. Default behaviour for short pages (<3500 chars) is unchanged. (#541 follow-up)
+
+### Technical Details
+- **Modified Files**: `container/agent-runner/_tools.py` (chunked logic), `container/agent-runner/_registry.py` (declarations for Gemini/OpenAI/Claude + dispatcher)
+- **Image rebuild required**: `docker build -t evoclaw-agent:latest container/`
+- **Breaking Changes**: None at the API level. Models that don't read the footer will see an extra suffix on long pages, which is correctly interpreted as "this is a partial response."
+
 ## [1.27.10] — 2026-04-20
 
 ### Fixed


### PR DESCRIPTION
Closes #546

## Why

Observed in production today: model received a long GitHub raw file via WebFetch and reported \"中間部分被截斷\" (middle was truncated).

Trace: WebFetch returned 50KB → LLM loop \`_MAX_TOOL_RESULT_CHARS=4000\` cap kept head 2KB + tail 2KB and dropped the middle. Model could not see the middle.

## What

Added optional \`offset\` and \`max_chars\` to WebFetch. Long pages are returned in chunks with a footer telling the model exactly how to fetch the next one:

\`\`\`
[chunk: chars 0-3500 of total 12345. To get the next chunk, call: WebFetch(url=..., offset=3500)]
\`\`\`

Default chunk size (3500 chars) stays under the 4 KB tool-result cap so the chunk + footer aren't further truncated. Short pages (< 3500 chars) return with no footer.

## Changes

- \`container/agent-runner/_tools.py\`: \`tool_web_fetch(url, offset=0, max_chars=3500)\` with input validation (offset >= 0, max_chars in [500, 8000])
- \`container/agent-runner/_registry.py\`: declarations updated for Gemini / OpenAI / Claude + dispatcher passes \`offset\`/\`max_chars\`
- \`docs/CHANGELOG.md\`: \`[1.27.11]\` under \`### Changed\`

## Test plan

- [x] Syntax check passes
- [ ] Post-merge: rebuild image, test with the exact URL from today's failure (\`Claude-Design-Sys-Prompt.txt\`), confirm model can iteratively fetch all chunks