### PR TITLE
feat(agent): summarizer model — WebFetch returns prompt-applied result (#548)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,3 +180,17 @@ GROUPS_DIR=groups
 # LEADER_HEARTBEAT_INTERVAL=10    # Seconds between heartbeats
 # LEADER_LEASE_TIMEOUT=30         # Seconds before lease considered expired
 # INSTANCE_ID=hostname:pid        # Unique ID (auto-detected by default)
+
+# ── Summarizer model (Issue #548) ─────────────────────────────────────────────
+# Optional cheap secondary model used by WebFetch (and other large-output tools)
+# to apply the user's prompt over the FULL fetched content instead of dumping
+# raw text into the main model's history. Mirrors Claude Code's WebFetchTool
+# design. When unset, WebFetch falls back to chunked raw text.
+#
+# SUMMARIZER_PROVIDER=openai-compat   # gemini | claude | openai-compat
+# SUMMARIZER_MODEL=meta/llama-3.1-8b-instruct
+# SUMMARIZER_API_KEY_REUSE=NIM_API_KEY  # share key with main backend
+# SUMMARIZER_API_KEY=                  # or set directly (used if _REUSE empty)
+# SUMMARIZER_BASE_URL=https://integrate.api.nvidia.com/v1
+# SUMMARIZER_MAX_TOKENS=1500
+# SUMMARIZER_TIMEOUT_S=30

--- a/container/agent-runner/_registry.py
+++ b/container/agent-runner/_registry.py
@@ -257,13 +257,14 @@ TOOL_DECLARATIONS = [] if not _GOOGLE_AVAILABLE or types is None else [
     ),
     types.FunctionDeclaration(
         name="WebFetch",
-        description="Fetch content from a URL and return it as plain text (chunked). Each call returns up to ~3500 chars starting at `offset`. If the response footer says `[chunk: chars X-Y of total Z]` and Y < Z, call again with offset=Y to get the next chunk.",
+        description="Fetch a URL and return its content as plain text. STRONGLY PREFER passing `prompt` (e.g. 'Translate to Chinese', 'Extract the install command'): the full content is processed by a cheap summarizer model and only the prompt-applied result is returned — much smaller and avoids context bloat. Without `prompt`, falls back to chunked raw text (offset/max_chars).",
         parameters=types.Schema(
             type=types.Type.OBJECT,
             properties={
                 "url": types.Schema(type=types.Type.STRING, description="The URL to fetch"),
-                "offset": types.Schema(type=types.Type.INTEGER, description="Starting character offset (default 0). Use the value from the previous response's footer to get the next chunk."),
-                "max_chars": types.Schema(type=types.Type.INTEGER, description="Max characters per chunk (default 3500, max 8000)."),
+                "prompt": types.Schema(type=types.Type.STRING, description="Recommended: task to apply over the fetched content (e.g. 'Translate to Chinese', 'Summarize the key points'). When set, a cheap summarizer model processes the full content and only the result is returned — avoids middle-truncation of long pages."),
+                "offset": types.Schema(type=types.Type.INTEGER, description="(Only when no prompt) Starting character offset for chunked raw fetch."),
+                "max_chars": types.Schema(type=types.Type.INTEGER, description="(Only when no prompt) Max characters per chunk."),
             },
             required=["url"],
         ),
@@ -374,7 +375,7 @@ OPENAI_TOOL_DECLARATIONS = [
     {"type": "function", "function": {"name": "mcp__evoclaw__resume_task", "description": "Resume a previously paused scheduled task.", "parameters": {"type": "object", "properties": {"task_id": {"type": "string", "description": "The task ID to resume"}}, "required": ["task_id"]}}},
     {"type": "function", "function": {"name": "Glob", "description": "Find files matching a glob pattern (supports ** recursive).", "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}}, "required": ["pattern"]}}},
     {"type": "function", "function": {"name": "Grep", "description": "Search file contents with regex. Returns filename:line:content.", "parameters": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}, "include": {"type": "string"}}, "required": ["pattern"]}}},
-    {"type": "function", "function": {"name": "WebFetch", "description": "Fetch a URL and return its content as plain text (chunked). Returns up to ~3500 chars starting at `offset`. If the footer reports more chars remaining, call again with offset=<end of previous chunk>.", "parameters": {"type": "object", "properties": {"url": {"type": "string"}, "offset": {"type": "integer", "description": "starting char offset, default 0"}, "max_chars": {"type": "integer", "description": "max chars per chunk, default 3500, max 8000"}}, "required": ["url"]}}},
+    {"type": "function", "function": {"name": "WebFetch", "description": "Fetch a URL. STRONGLY PREFER passing `prompt` so a cheap summarizer model processes the full content and returns only the result (avoids context bloat + middle-truncation). Without prompt: chunked raw text via offset/max_chars.", "parameters": {"type": "object", "properties": {"url": {"type": "string"}, "prompt": {"type": "string", "description": "Recommended: task to apply (e.g. 'Translate to Chinese', 'Summarize key points')"}, "offset": {"type": "integer", "description": "(only without prompt) starting char offset, default 0"}, "max_chars": {"type": "integer", "description": "(only without prompt) max chars per chunk, default 3500, max 8000"}}, "required": ["url"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__run_agent", "description": "Spawn a subagent in an isolated Docker container to handle a subtask. Blocks until complete (up to 300s) and returns its output.", "parameters": {"type": "object", "properties": {"prompt": {"type": "string", "description": "The task for the subagent"}, "context_mode": {"type": "string", "description": "isolated or group"}}, "required": ["prompt"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__send_file", "description": "Send a file to the user. Write the file to /workspace/group/output/ first, then call this tool.", "parameters": {"type": "object", "properties": {"chat_jid": {"type": "string", "description": "The chat JID to send the file to"}, "file_path": {"type": "string", "description": "Absolute container path to the file"}, "caption": {"type": "string", "description": "Optional caption"}}, "required": ["file_path"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__reset_group", "description": "Clear the failure counter for a group, unfreezing it if it was locked in cooldown. Use when a group is stuck and not responding.", "parameters": {"type": "object", "properties": {"jid": {"type": "string", "description": "The JID of the group to reset, e.g. tg:8259652816"}}, "required": ["jid"]}}},
@@ -399,7 +400,7 @@ CLAUDE_TOOL_DECLARATIONS = [
     {"name": "mcp__evoclaw__resume_task", "description": "Resume a previously paused scheduled task.", "input_schema": {"type": "object", "properties": {"task_id": {"type": "string", "description": "The task ID to resume"}}, "required": ["task_id"]}},
     {"name": "Glob", "description": "Find files matching a glob pattern (supports ** recursive).", "input_schema": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}}, "required": ["pattern"]}},
     {"name": "Grep", "description": "Search file contents with regex. Returns filename:line:content.", "input_schema": {"type": "object", "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}, "include": {"type": "string"}}, "required": ["pattern"]}},
-    {"name": "WebFetch", "description": "Fetch a URL and return its content as plain text (chunked). Returns up to ~3500 chars starting at `offset`. If the footer reports more chars remaining, call again with offset=<end of previous chunk>.", "input_schema": {"type": "object", "properties": {"url": {"type": "string"}, "offset": {"type": "integer", "description": "starting char offset, default 0"}, "max_chars": {"type": "integer", "description": "max chars per chunk, default 3500, max 8000"}}, "required": ["url"]}},
+    {"name": "WebFetch", "description": "Fetch a URL. STRONGLY PREFER passing `prompt` so a cheap summarizer model processes the full content and returns only the result (avoids context bloat + middle-truncation). Without prompt: chunked raw text via offset/max_chars.", "input_schema": {"type": "object", "properties": {"url": {"type": "string"}, "prompt": {"type": "string", "description": "Recommended: task to apply (e.g. 'Translate to Chinese', 'Summarize key points')"}, "offset": {"type": "integer", "description": "(only without prompt) starting char offset, default 0"}, "max_chars": {"type": "integer", "description": "(only without prompt) max chars per chunk, default 3500, max 8000"}}, "required": ["url"]}},
     {"name": "mcp__evoclaw__run_agent", "description": "Spawn a subagent in an isolated Docker container to handle a subtask. Blocks until complete (up to 300s) and returns its output.", "input_schema": {"type": "object", "properties": {"prompt": {"type": "string", "description": "The task for the subagent"}, "context_mode": {"type": "string", "description": "isolated or group"}}, "required": ["prompt"]}},
     {"name": "mcp__evoclaw__send_file", "description": "Send a file to the user. Write the file to /workspace/group/output/ first, then call this tool.", "input_schema": {"type": "object", "properties": {"chat_jid": {"type": "string", "description": "The chat JID to send the file to"}, "file_path": {"type": "string", "description": "Absolute container path to the file"}, "caption": {"type": "string", "description": "Optional caption"}}, "required": ["file_path"]}},
     {"name": "mcp__evoclaw__reset_group", "description": "Clear the failure counter for a group, unfreezing it if it was locked in cooldown. Use when a group is stuck and not responding.", "input_schema": {"type": "object", "properties": {"jid": {"type": "string", "description": "The JID of the group to reset, e.g. tg:8259652816"}}, "required": ["jid"]}},
@@ -498,9 +499,10 @@ def _execute_tool_inner(name: str, args: dict, chat_jid: str) -> str:
         _url = args.get("url")
         if not isinstance(_url, str):
             return "Error: WebFetch requires a 'url' string argument"
+        _prompt = args.get("prompt", "") or ""
         _offset = args.get("offset", 0)
         _max_chars = args.get("max_chars", 3500)
-        return tool_web_fetch(_url, offset=_offset, max_chars=_max_chars)
+        return tool_web_fetch(_url, prompt=_prompt, offset=_offset, max_chars=_max_chars)
     elif name == "mcp__evoclaw__run_agent":
         _ra_prompt = args.get("prompt")
         if not isinstance(_ra_prompt, str):

--- a/container/agent-runner/_summarizer.py
+++ b/container/agent-runner/_summarizer.py
@@ -1,0 +1,220 @@
+"""Summarizer subsystem (Issue #548).
+
+Inspired by Claude Code's WebFetchTool — instead of dumping raw fetched
+content to the main model, run it through a cheap secondary model with the
+user's prompt and return only the prompt-applied result.
+
+This module is intentionally **provider-agnostic** but does NOT require
+the larger refactor in #549.  Internally it dispatches to the appropriate
+SDK based on env config; #549 will collapse this dispatch into a unified
+LLMClient interface.
+
+Configuration via env vars (operator sets these in .env):
+
+    SUMMARIZER_PROVIDER   = "openai-compat" | "gemini" | "claude" | "" (disabled)
+    SUMMARIZER_MODEL      = e.g. "meta/llama-3.1-8b-instruct"
+    SUMMARIZER_API_KEY_REUSE = name of another env var to read the key from
+                               (e.g. "NIM_API_KEY") — useful when the
+                               summarizer shares a key with the main backend
+    SUMMARIZER_API_KEY    = direct key (used if _REUSE not set)
+    SUMMARIZER_BASE_URL   = e.g. "https://integrate.api.nvidia.com/v1"
+    SUMMARIZER_MAX_TOKENS = default 1500
+    SUMMARIZER_TIMEOUT_S  = default 30
+
+If SUMMARIZER_PROVIDER is empty/unset, all summarize calls return None and
+callers fall back to truncation.
+"""
+from __future__ import annotations
+
+import os
+import time
+import threading
+from typing import Optional
+
+from _utils import _log
+
+
+# ── In-memory cache (5 min TTL) ────────────────────────────────────────────────
+# Same (url, prompt) within 5 minutes → cached.  Prevents the model-loop case
+# observed 2026-04-20 where the LLM kept calling WebFetch on the same URL.
+_CACHE_TTL_SECS = 300
+_cache: dict = {}  # key = (url, prompt) → (timestamp, result)
+_cache_lock = threading.Lock()
+
+
+def _cache_get(key: tuple) -> Optional[str]:
+    with _cache_lock:
+        entry = _cache.get(key)
+        if entry is None:
+            return None
+        ts, val = entry
+        if time.time() - ts > _CACHE_TTL_SECS:
+            _cache.pop(key, None)
+            return None
+        return val
+
+
+def _cache_set(key: tuple, value: str) -> None:
+    with _cache_lock:
+        # Evict oldest 25% if cache grows past 100 entries
+        if len(_cache) >= 100:
+            sorted_items = sorted(_cache.items(), key=lambda x: x[1][0])
+            for k, _ in sorted_items[: 25]:
+                _cache.pop(k, None)
+        _cache[key] = (time.time(), value)
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+def _get_config() -> dict:
+    """Read summarizer config from env each call (cheap, allows hot reload)."""
+    provider = (os.environ.get("SUMMARIZER_PROVIDER", "") or "").strip().lower()
+    model = os.environ.get("SUMMARIZER_MODEL", "").strip()
+    if not provider or not model:
+        return {"enabled": False}
+
+    key_reuse = os.environ.get("SUMMARIZER_API_KEY_REUSE", "").strip()
+    api_key = os.environ.get(key_reuse, "") if key_reuse else os.environ.get("SUMMARIZER_API_KEY", "")
+    if not api_key:
+        return {"enabled": False, "reason": "no_api_key"}
+
+    try:
+        max_tokens = int(os.environ.get("SUMMARIZER_MAX_TOKENS", "1500"))
+    except ValueError:
+        max_tokens = 1500
+    try:
+        timeout_s = float(os.environ.get("SUMMARIZER_TIMEOUT_S", "30"))
+    except ValueError:
+        timeout_s = 30.0
+
+    return {
+        "enabled": True,
+        "provider": provider,
+        "model": model,
+        "api_key": api_key,
+        "base_url": os.environ.get("SUMMARIZER_BASE_URL", "").strip(),
+        "max_tokens": max_tokens,
+        "timeout_s": timeout_s,
+    }
+
+
+def is_enabled() -> bool:
+    return _get_config().get("enabled", False)
+
+
+# ── Provider-specific call paths (lazy imports) ────────────────────────────────
+def _call_openai_compat(cfg: dict, system: str, user: str) -> str:
+    from openai import OpenAI
+    import httpx
+    timeout = httpx.Timeout(connect=15.0, read=cfg["timeout_s"], write=15.0, pool=10.0)
+    base_url = cfg["base_url"] or "https://api.openai.com/v1"
+    client = OpenAI(base_url=base_url, api_key=cfg["api_key"], timeout=timeout)
+    resp = client.chat.completions.create(
+        model=cfg["model"],
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        temperature=0.2,
+        max_tokens=cfg["max_tokens"],
+    )
+    return (resp.choices[0].message.content or "").strip()
+
+
+def _call_gemini(cfg: dict, system: str, user: str) -> str:
+    from google import genai
+    from google.genai import types
+    client = genai.Client(api_key=cfg["api_key"])
+    cfg_obj = types.GenerateContentConfig(
+        system_instruction=system,
+        temperature=0.2,
+        max_output_tokens=cfg["max_tokens"],
+    )
+    resp = client.models.generate_content(
+        model=cfg["model"],
+        contents=user,
+        config=cfg_obj,
+    )
+    return (resp.text or "").strip()
+
+
+def _call_claude(cfg: dict, system: str, user: str) -> str:
+    import anthropic
+    client = anthropic.Anthropic(api_key=cfg["api_key"], timeout=cfg["timeout_s"])
+    resp = client.messages.create(
+        model=cfg["model"],
+        system=system,
+        messages=[{"role": "user", "content": user}],
+        max_tokens=cfg["max_tokens"],
+        temperature=0.2,
+    )
+    parts = []
+    for block in resp.content:
+        text = getattr(block, "text", "")
+        if text:
+            parts.append(text)
+    return "".join(parts).strip()
+
+
+_DISPATCH = {
+    "openai-compat": _call_openai_compat,
+    "openai": _call_openai_compat,
+    "nim": _call_openai_compat,
+    "gemini": _call_gemini,
+    "google": _call_gemini,
+    "claude": _call_claude,
+    "anthropic": _call_claude,
+}
+
+
+# ── Public entry ───────────────────────────────────────────────────────────────
+_DEFAULT_SYSTEM = (
+    "You are a precise content processor.  Apply the user's prompt to the "
+    "provided content.  Return ONLY the requested result — no preamble, no "
+    "meta-commentary, no markdown fences unless the prompt asks for code."
+)
+
+
+def summarize(content: str, prompt: str, *, cache_key: Optional[tuple] = None) -> Optional[str]:
+    """Apply prompt to content via the configured summarizer model.
+
+    Returns the model's text output, or None if:
+        * summarizer not configured
+        * provider unknown
+        * call failed (logged + returns None so caller can fall back)
+
+    cache_key, if provided, enables 5-min in-memory caching keyed by it.
+    """
+    if not content:
+        return None
+    cfg = _get_config()
+    if not cfg.get("enabled"):
+        return None
+
+    if cache_key is not None:
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            _log("📋 SUM-CACHE", f"hit key={cache_key[0][:60]!r}")
+            return cached
+
+    fn = _DISPATCH.get(cfg["provider"])
+    if fn is None:
+        _log("⚠️ SUM-CFG", f"unknown SUMMARIZER_PROVIDER={cfg['provider']!r}")
+        return None
+
+    user = f"<content>\n{content}\n</content>\n\n<task>\n{prompt}\n</task>"
+    t0 = time.time()
+    try:
+        result = fn(cfg, _DEFAULT_SYSTEM, user)
+    except Exception as exc:
+        _log("⚠️ SUM-FAIL", f"provider={cfg['provider']} model={cfg['model']} err={type(exc).__name__}: {exc}")
+        return None
+    dur_ms = int((time.time() - t0) * 1000)
+    _log(
+        "✨ SUM-OK",
+        f"provider={cfg['provider']} model={cfg['model']} "
+        f"in={len(content)}B out={len(result)}B dur={dur_ms}ms",
+    )
+
+    if cache_key is not None:
+        _cache_set(cache_key, result)
+    return result

--- a/container/agent-runner/_tools.py
+++ b/container/agent-runner/_tools.py
@@ -979,7 +979,7 @@ def tool_grep(pattern: str, path: str = WORKSPACE, include: str = "*") -> str:
                 pass
 
 
-def tool_web_fetch(url: str, offset: int = 0, max_chars: int = 3500) -> str:
+def tool_web_fetch(url: str, prompt: str = "", offset: int = 0, max_chars: int = 3500) -> str:
     """
     從指定 URL 抓取網頁內容，自動將 HTML 轉換為純文字。
     適合查閱文件、新聞、GitHub README 等網頁資料。
@@ -1237,6 +1237,26 @@ def tool_web_fetch(url: str, offset: int = 0, max_chars: int = 3500) -> str:
         total_chars = len(text)
         if total_chars == 0:
             return "(empty response)"
+
+        # Issue #548: if a prompt is given AND a summarizer is configured,
+        # apply the prompt over the FULL fetched content via a cheap secondary
+        # model and return only the result.  This mirrors Claude Code's
+        # WebFetchTool design and avoids the main-model history bloat caused
+        # by stuffing raw page content back into the conversation.
+        if prompt:
+            try:
+                from _summarizer import summarize as _summarize, is_enabled as _sum_enabled
+                if _sum_enabled():
+                    cache_key = (url, prompt.strip()[:200])
+                    summary = _summarize(text, prompt, cache_key=cache_key)
+                    if summary:
+                        cap_note = " (source 50KB-capped)" if _truncated_at_50k else ""
+                        return f"{summary}\n\n[summarized: source {total_chars}chars{cap_note} → {len(summary)}chars via summarizer model]"
+                    # Summarizer failed → fall through to chunked
+                    _log("⚠️ SUM-FALLBACK", "summarizer returned None, using chunked WebFetch")
+            except Exception as _sum_err:
+                _log("⚠️ SUM-IMPORT", f"summarizer module error: {_sum_err}")
+                # Fall through to chunked
 
         # Issue #541 follow-up: chunked return.
         if offset >= total_chars:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.27.12] — 2026-04-22
+
+### Added
+- **Summarizer model — WebFetch returns prompt-applied result, not raw content.** Inspired by Claude Code's WebFetchTool design (extracted via `claude-code-reference`). Operators set `SUMMARIZER_PROVIDER` (openai-compat / gemini / claude) + `SUMMARIZER_MODEL`. When set, `WebFetch(url, prompt="...")` runs the full fetched content through the cheap secondary model with the user's prompt and returns only the result — no raw page in the main model's history. Eliminates the chunked-fetch loop, the `_MAX_TOOL_RESULT_CHARS=4000` middle-truncation, and the history bloat OOM chain in one move. Includes 5-min in-memory `(url, prompt)` cache to handle the runaway-loop case observed 2026-04-20. Backward-compatible: when summarizer is unconfigured or call fails, falls back to the chunked raw-text behaviour from #547. (#548)
+
+### Technical Details
+- **New Files**: `container/agent-runner/_summarizer.py` (provider-agnostic dispatcher with lazy SDK imports)
+- **Modified Files**: `container/agent-runner/_tools.py` (`tool_web_fetch` accepts `prompt`), `container/agent-runner/_registry.py` (declarations + dispatcher updated for Gemini/OpenAI/Claude), `.env.example` (documents new env vars)
+- **New Env Vars**: `SUMMARIZER_PROVIDER`, `SUMMARIZER_MODEL`, `SUMMARIZER_API_KEY` / `SUMMARIZER_API_KEY_REUSE`, `SUMMARIZER_BASE_URL`, `SUMMARIZER_MAX_TOKENS`, `SUMMARIZER_TIMEOUT_S`
+- **Image rebuild required**: `docker build -t evoclaw-agent:latest container/`
+- **Breaking Changes**: None.
+- **Follow-up**: #549 will refactor the per-provider dispatch in `_summarizer.py` (and the `_loop_*.py`) into a unified `LLMClient` interface.
+
 ## [1.27.11] — 2026-04-21
 
 ### Changed


### PR DESCRIPTION
Closes #548 (PR 1 of 2; #549 is the follow-up refactor)

## Why

Inspired by Claude Code's WebFetchTool (see \`claude-code-reference\`): the official tool fetches the URL and runs a small model (Haiku) over the full content with the user's \`prompt\`, returning only the result to the main model.

evoclaw was dumping the raw 50KB → main model's history → \`_MAX_TOOL_RESULT_CHARS=4000\` middle-truncation → user sees \"中間部分被截斷\". The chunked WebFetch in #547 was a workaround. This PR is the root fix.

## What

- New module \`container/agent-runner/_summarizer.py\` — provider-agnostic dispatcher (openai-compat / gemini / claude) with lazy SDK imports + 5-min \`(url, prompt)\` cache.
- \`tool_web_fetch(url, prompt=\"\", ...)\` — when \`prompt\` is set AND \`SUMMARIZER_PROVIDER\` configured, apply prompt over full content via secondary model, return only result. Otherwise falls back to chunked behavior from #547.
- Updated tool declarations for Gemini / OpenAI / Claude — description nudges the model to pass \`prompt\`.
- \`.env.example\` documents the new env vars.

## Operator config

\`\`\`env
SUMMARIZER_PROVIDER=openai-compat
SUMMARIZER_MODEL=meta/llama-3.1-8b-instruct
SUMMARIZER_API_KEY_REUSE=NIM_API_KEY
SUMMARIZER_BASE_URL=https://integrate.api.nvidia.com/v1
\`\`\`

## Test plan

- [x] Syntax check passes
- [ ] Post-merge: rebuild image, set summarizer in .env, send Telegram \"翻譯這個 URL 內容: ...\", confirm \`✨ SUM-OK\` log + main model receives summarizer output (not raw content)
- [ ] Negative test: SUMMARIZER_PROVIDER unset → behavior unchanged (chunked raw text)
- [ ] Failure test: invalid SUMMARIZER_API_KEY → \`⚠️ SUM-FAIL\` logged + falls back to chunked