### PR TITLE
refactor(agent): extract _llm_client.py unified interface (#549)

### DIFF
--- a/container/agent-runner/_llm_client.py
+++ b/container/agent-runner/_llm_client.py
@@ -1,0 +1,162 @@
+"""LLMClient — unified interface over Gemini / OpenAI-compat / Claude SDKs.
+
+Issue #549. Eliminates the per-provider dispatching duplicated between
+`_summarizer.py` and (eventually) `_loop_*.py`.
+
+Scope of THIS PR
+----------------
+This PR ships **simple completion** support — one prompt in, text out.
+Streaming + tool-calls (needed by the agentic loops in `_loop_openai.py`,
+`_loop_gemini.py`, `_loop_claude.py`) is a follow-up.
+
+That ordering is deliberate:
+1. summarizer is the lowest-risk consumer — failures degrade gracefully
+2. proves the interface works before we touch the OOM-prone main loop
+3. lets us iterate the interface based on real usage before locking it in
+
+Design
+------
+LLMClient is a Protocol — no inheritance, no base class. Adapters are
+plain dataclasses so adding a backend is `make_client()` + a 30-line
+adapter and nothing else.
+
+Adapters do **lazy SDK imports** (matching the pattern in `agent.py`)
+so that loading the openai-compat adapter does NOT pull google-genai
+into memory.
+
+Configuration
+-------------
+make_client() takes provider/model/api_key/base_url/timeout. Callers
+that read env vars (e.g. _summarizer._get_config()) hand the values in;
+the adapter doesn't touch os.environ.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class CompletionResult:
+    """Shape returned by every adapter's complete() call."""
+    text: str
+    # raw provider response, for callers that want extra metadata.  Avoid
+    # depending on this — keep all logic against `text`.
+    raw: object = None
+
+
+class LLMClient(Protocol):
+    provider: str
+    model: str
+
+    def complete(self, system: str, user: str, *, max_tokens: int = 1500, temperature: float = 0.2) -> CompletionResult:
+        """Run a single-turn completion. system + user → text."""
+        ...
+
+
+# ── Adapters ──────────────────────────────────────────────────────────────────
+@dataclass
+class _OpenAICompatClient:
+    provider: str
+    model: str
+    api_key: str
+    base_url: str
+    timeout_s: float
+
+    def complete(self, system: str, user: str, *, max_tokens: int = 1500, temperature: float = 0.2) -> CompletionResult:
+        from openai import OpenAI
+        import httpx
+        timeout = httpx.Timeout(connect=15.0, read=self.timeout_s, write=15.0, pool=10.0)
+        base = self.base_url or "https://api.openai.com/v1"
+        client = OpenAI(base_url=base, api_key=self.api_key, timeout=timeout)
+        resp = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        text = (resp.choices[0].message.content or "").strip()
+        return CompletionResult(text=text, raw=resp)
+
+
+@dataclass
+class _GeminiClient:
+    provider: str
+    model: str
+    api_key: str
+    base_url: str       # unused for Gemini (kept for interface symmetry)
+    timeout_s: float    # not directly enforceable on google-genai sync calls
+
+    def complete(self, system: str, user: str, *, max_tokens: int = 1500, temperature: float = 0.2) -> CompletionResult:
+        from google import genai
+        from google.genai import types
+        client = genai.Client(api_key=self.api_key)
+        cfg = types.GenerateContentConfig(
+            system_instruction=system,
+            temperature=temperature,
+            max_output_tokens=max_tokens,
+        )
+        resp = client.models.generate_content(model=self.model, contents=user, config=cfg)
+        text = (resp.text or "").strip()
+        return CompletionResult(text=text, raw=resp)
+
+
+@dataclass
+class _ClaudeClient:
+    provider: str
+    model: str
+    api_key: str
+    base_url: str       # passed to anthropic.Anthropic if non-empty
+    timeout_s: float
+
+    def complete(self, system: str, user: str, *, max_tokens: int = 1500, temperature: float = 0.2) -> CompletionResult:
+        import anthropic
+        kwargs = {"api_key": self.api_key, "timeout": self.timeout_s}
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        client = anthropic.Anthropic(**kwargs)
+        resp = client.messages.create(
+            model=self.model,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        parts = []
+        for block in resp.content:
+            t = getattr(block, "text", "")
+            if t:
+                parts.append(t)
+        return CompletionResult(text="".join(parts).strip(), raw=resp)
+
+
+# ── Factory ───────────────────────────────────────────────────────────────────
+# Aliases let operators write provider names that match common conventions.
+_PROVIDER_ALIASES = {
+    "openai-compat": _OpenAICompatClient,
+    "openai": _OpenAICompatClient,
+    "nim": _OpenAICompatClient,
+    "groq": _OpenAICompatClient,
+    "qwen": _OpenAICompatClient,
+    "gemini": _GeminiClient,
+    "google": _GeminiClient,
+    "claude": _ClaudeClient,
+    "anthropic": _ClaudeClient,
+}
+
+
+def make_client(provider: str, model: str, api_key: str, *, base_url: str = "", timeout_s: float = 30.0) -> LLMClient:
+    """Construct an adapter for the named provider.
+
+    Raises ValueError on unknown provider; callers should catch this if
+    they want to log + skip rather than abort.
+    """
+    cls = _PROVIDER_ALIASES.get(provider.lower())
+    if cls is None:
+        raise ValueError(f"Unknown LLM provider {provider!r}. Known: {sorted(set(_PROVIDER_ALIASES.keys()))}")
+    return cls(provider=provider, model=model, api_key=api_key, base_url=base_url, timeout_s=timeout_s)
+
+
+def known_providers() -> list[str]:
+    """For diagnostics + config validation."""
+    return sorted(set(_PROVIDER_ALIASES.keys()))

--- a/container/agent-runner/_summarizer.py
+++ b/container/agent-runner/_summarizer.py
@@ -101,71 +101,6 @@ def is_enabled() -> bool:
     return _get_config().get("enabled", False)
 
 
-# ── Provider-specific call paths (lazy imports) ────────────────────────────────
-def _call_openai_compat(cfg: dict, system: str, user: str) -> str:
-    from openai import OpenAI
-    import httpx
-    timeout = httpx.Timeout(connect=15.0, read=cfg["timeout_s"], write=15.0, pool=10.0)
-    base_url = cfg["base_url"] or "https://api.openai.com/v1"
-    client = OpenAI(base_url=base_url, api_key=cfg["api_key"], timeout=timeout)
-    resp = client.chat.completions.create(
-        model=cfg["model"],
-        messages=[
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-        temperature=0.2,
-        max_tokens=cfg["max_tokens"],
-    )
-    return (resp.choices[0].message.content or "").strip()
-
-
-def _call_gemini(cfg: dict, system: str, user: str) -> str:
-    from google import genai
-    from google.genai import types
-    client = genai.Client(api_key=cfg["api_key"])
-    cfg_obj = types.GenerateContentConfig(
-        system_instruction=system,
-        temperature=0.2,
-        max_output_tokens=cfg["max_tokens"],
-    )
-    resp = client.models.generate_content(
-        model=cfg["model"],
-        contents=user,
-        config=cfg_obj,
-    )
-    return (resp.text or "").strip()
-
-
-def _call_claude(cfg: dict, system: str, user: str) -> str:
-    import anthropic
-    client = anthropic.Anthropic(api_key=cfg["api_key"], timeout=cfg["timeout_s"])
-    resp = client.messages.create(
-        model=cfg["model"],
-        system=system,
-        messages=[{"role": "user", "content": user}],
-        max_tokens=cfg["max_tokens"],
-        temperature=0.2,
-    )
-    parts = []
-    for block in resp.content:
-        text = getattr(block, "text", "")
-        if text:
-            parts.append(text)
-    return "".join(parts).strip()
-
-
-_DISPATCH = {
-    "openai-compat": _call_openai_compat,
-    "openai": _call_openai_compat,
-    "nim": _call_openai_compat,
-    "gemini": _call_gemini,
-    "google": _call_gemini,
-    "claude": _call_claude,
-    "anthropic": _call_claude,
-}
-
-
 # ── Public entry ───────────────────────────────────────────────────────────────
 _DEFAULT_SYSTEM = (
     "You are a precise content processor.  Apply the user's prompt to the "
@@ -196,15 +131,24 @@ def summarize(content: str, prompt: str, *, cache_key: Optional[tuple] = None) -
             _log("📋 SUM-CACHE", f"hit key={cache_key[0][:60]!r}")
             return cached
 
-    fn = _DISPATCH.get(cfg["provider"])
-    if fn is None:
-        _log("⚠️ SUM-CFG", f"unknown SUMMARIZER_PROVIDER={cfg['provider']!r}")
+    # Issue #549: dispatch via the unified LLMClient interface.
+    from _llm_client import make_client
+    try:
+        client = make_client(
+            provider=cfg["provider"],
+            model=cfg["model"],
+            api_key=cfg["api_key"],
+            base_url=cfg.get("base_url", ""),
+            timeout_s=cfg["timeout_s"],
+        )
+    except ValueError as cfg_err:
+        _log("⚠️ SUM-CFG", str(cfg_err))
         return None
 
     user = f"<content>\n{content}\n</content>\n\n<task>\n{prompt}\n</task>"
     t0 = time.time()
     try:
-        result = fn(cfg, _DEFAULT_SYSTEM, user)
+        result = client.complete(_DEFAULT_SYSTEM, user, max_tokens=cfg["max_tokens"]).text
     except Exception as exc:
         _log("⚠️ SUM-FAIL", f"provider={cfg['provider']} model={cfg['model']} err={type(exc).__name__}: {exc}")
         return None

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.27.13] — 2026-04-22
+
+### Changed
+- **Extracted `_llm_client.py` unified interface (PR 2 of summarizer arc).** Eliminates the duplicated per-provider dispatch in `_summarizer.py`. Adds `LLMClient` Protocol + `_OpenAICompatClient`, `_GeminiClient`, `_ClaudeClient` adapters + `make_client(provider, model, api_key, base_url, timeout_s)` factory. `_summarizer.summarize()` now delegates to `make_client().complete()`. Adapters keep lazy SDK imports — loading the openai-compat adapter does not pull google-genai. **Scope**: simple completion (system + user → text) only; streaming + tool-calls (needed by `_loop_*.py` agentic loops) is a follow-up. (#549)
+
+### Technical Details
+- **New Files**: `container/agent-runner/_llm_client.py`
+- **Modified Files**: `container/agent-runner/_summarizer.py` (now uses `make_client`); per-provider call functions removed
+- **Image rebuild required**: `docker build -t evoclaw-agent:latest container/`
+- **Breaking Changes**: None. The summarizer's external behavior (env vars, output format, fallback path, cache) is unchanged.
+
 ## [1.27.12] — 2026-04-22
 
 ### Added


### PR DESCRIPTION
Closes #549 (partial — completion path; streaming + tool-calls migration deferred)

## Why

After #548 shipped the summarizer, the per-provider dispatch logic exists in TWO places (\`_summarizer.py\` and the future \`_loop_*.py\` migration). This PR extracts the shared shape so both can call one interface.

## What

- New module \`container/agent-runner/_llm_client.py\`:
  - \`LLMClient\` Protocol + \`CompletionResult\` dataclass
  - 3 adapters: \`_OpenAICompatClient\`, \`_GeminiClient\`, \`_ClaudeClient\` — plain dataclasses with lazy SDK imports
  - \`make_client(provider, model, api_key, base_url, timeout_s)\` factory
  - \`known_providers()\` for diagnostics
- \`_summarizer.py\` refactored to call \`make_client().complete()\` instead of the per-provider \`_call_*()\` helpers (which are now removed).

## Scope

**This PR ships completion-only support.** Streaming + tool-calls (needed to migrate \`_loop_openai.py\` / \`_loop_gemini.py\` / \`_loop_claude.py\`) is intentionally deferred:

- The agentic-loop interface needs tool_choice, tool_calls accumulation, streaming deltas, finish_reason — much richer surface than completion.
- Migrating the OOM-prone \`_loop_openai.py\` is high risk; want the interface validated end-to-end via summarizer first.
- Issue #549 explicitly listed this incremental migration plan.

## Test plan

- [x] Syntax check passes
- [x] \`_summarizer.py\` imports cleanly with new dependency
- [ ] Post-merge: rebuild image, run a WebFetch with prompt, confirm summarizer still works (proves the new interface end-to-end)
- [ ] No env var or output format change for operators