### PR TITLE
docs: README updates for summarizer model (#548, #549)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,8 +520,31 @@ cp .env.example .env
 | `MAX_CONCURRENT_CONTAINERS` | 全局最大並發容器數 | 選填 |
 | `GEMINI_MODEL` | Gemini 模型名稱（例：`gemini-2.0-flash-exp`） | 選填 |
 | `ENABLED_CHANNELS` | 啟用的頻道（例：`telegram,discord,slack`） | 選填 |
+| `SUMMARIZER_PROVIDER` | 副模型 provider（`openai-compat`/`gemini`/`claude`，空白=停用） | 選填 |
+| `SUMMARIZER_MODEL` | 副模型名稱（例：`meta/llama-3.1-8b-instruct`） | 選填 |
+| `SUMMARIZER_API_KEY_REUSE` | 重用主 backend 的金鑰（例：`NIM_API_KEY`） | 選填 |
+| `SUMMARIZER_BASE_URL` | 副模型 API endpoint | 選填 |
 
 > **安全提醒**：使用 WhatsApp 時務必設定 `WHATSAPP_APP_SECRET`。未設定時，webhook 端點將接受來自任何來源的 payload。
+
+### 副模型 (Summarizer) — Issue #548 / #549
+
+靈感來自 Claude Code 官方 WebFetchTool 設計。啟用後，`WebFetch(url, prompt="...")` 會將**完整頁面內容**丟給一個便宜的小模型處理，只把結果（不是原始網頁）回給主模型。
+
+**解決的問題**：
+- 長 URL 內容被 `_MAX_TOOL_RESULT_CHARS=4000` 截掉中間（頭+尾保留、中間挖掉）
+- 主模型 history 膨脹 → pydantic spike → OOM
+
+**設定範例**（NIM 主 backend 共用金鑰）：
+
+```env
+SUMMARIZER_PROVIDER=openai-compat
+SUMMARIZER_MODEL=meta/llama-3.1-8b-instruct
+SUMMARIZER_API_KEY_REUSE=NIM_API_KEY
+SUMMARIZER_BASE_URL=https://integrate.api.nvidia.com/v1
+```
+
+未設定時（預設）：退回 chunked raw-text 行為（#547），完全不影響現有部署。
 
 ### 支援頻道
 

--- a/README_en.md
+++ b/README_en.md
@@ -51,6 +51,17 @@ cp .env.example .env
 
 Key env vars: `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `DASHBOARD_PASSWORD`.
 
+**Optional: summarizer model** (Issue #548) — have WebFetch apply a prompt over the full page content via a cheap secondary model instead of returning raw text:
+
+```env
+SUMMARIZER_PROVIDER=openai-compat   # or gemini | claude
+SUMMARIZER_MODEL=meta/llama-3.1-8b-instruct
+SUMMARIZER_API_KEY_REUSE=NIM_API_KEY   # share key with main backend
+SUMMARIZER_BASE_URL=https://integrate.api.nvidia.com/v1
+```
+
+When set, `WebFetch(url, prompt="Translate to Chinese")` runs the full content through the summarizer and returns only the result — avoids history bloat and middle-truncation on long pages. Unset = unchanged behaviour.
+
 > See [README.md](README.md) for the full configuration reference and all documentation.
 
 ## License


### PR DESCRIPTION
Refs #548 #549

## Summary

Documents the summarizer model configuration (PR #550 #551) in both \`README.md\` (zh) and \`README_en.md\` (en):

- New env-var table rows in zh README (\`SUMMARIZER_PROVIDER\`, \`SUMMARIZER_MODEL\`, \`SUMMARIZER_API_KEY_REUSE\`, \`SUMMARIZER_BASE_URL\`)
- New \"副模型 (Summarizer)\" section explaining the design inspiration (Claude Code's WebFetchTool) and the problem it solves
- English README quick note + config snippet

No code changes.

Label: \`skip-changelog\` — docs-only, no runtime behaviour change.