### PR TITLE
fix(host): propagate SUMMARIZER_* env vars to container (#555)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.27.15] — 2026-04-27
+
+### Fixed
+- **Summarizer (#548) was never actually invoked because `SUMMARIZER_*` env vars never reached the container.** `host/container_runner.py:_get_secrets()` reads only an explicit allowlist from `.env` and ships that allowlist via stdin JSON; the `SUMMARIZER_*` keys were missing. Inside the container, `_summarizer.is_enabled()` saw empty env vars → returned False → WebFetch fell back to chunked raw text → main model received raw page → OOM at turn=2 (observed 2026-04-27 16:43:53 with raw Instagram embed text echoed back). Added the seven `SUMMARIZER_*` keys to the secrets allowlist so the existing `agent.py` `os.environ[k] = v` injection picks them up. (#555)
+
+### Technical Details
+- **Modified Files**: `host/container_runner.py`
+- **Image rebuild required**: No (host-side change only)
+- **Breaking Changes**: None.
+
 ## [1.27.14] — 2026-04-24
 
 ### Fixed

--- a/host/container_runner.py
+++ b/host/container_runner.py
@@ -208,7 +208,18 @@ def _read_secrets() -> dict:
         "OPENAI_API_KEY", "OPENAI_MODEL", "OPENAI_BASE_URL",
         "CLAUDE_API_KEY", "ANTHROPIC_API_KEY", "CLAUDE_MODEL",
         "ASSISTANT_NAME",
+        # Issue #555: summarizer config must reach the container.  agent.py:159
+        # promotes every secret to os.environ inside the container, so adding
+        # these keys here is sufficient — _summarizer.py reads them via
+        # os.environ.get().
+        "SUMMARIZER_PROVIDER", "SUMMARIZER_MODEL",
+        "SUMMARIZER_API_KEY", "SUMMARIZER_API_KEY_REUSE",
+        "SUMMARIZER_BASE_URL", "SUMMARIZER_MAX_TOKENS", "SUMMARIZER_TIMEOUT_S",
     ])
+    # If SUMMARIZER_API_KEY_REUSE points to another key (e.g. NIM_API_KEY),
+    # resolve it now — the container's `os.environ.get(reuse_name)` will only
+    # work if that source key is also in `secrets`.  Source keys are already
+    # in the list above, so the lookup will succeed inside the container.
     # p21c: ANTHROPIC_API_KEY alias — users who follow the README_en.md example
     # (which referenced ANTHROPIC_API_KEY) silently fell back to Gemini.
     # If CLAUDE_API_KEY is absent but ANTHROPIC_API_KEY is set, promote the alias.


### PR DESCRIPTION
Closes #555

## Why

Summarizer (#548) was enabled in \`.env\` but never invoked. Today's OOM (2026-04-27 16:43:53) shows raw Instagram embed text dumped back into history — no \`✨ SUM-OK\` marker anywhere → summarizer never ran.

Root cause: \`_get_secrets()\` ships an allowlist of keys from \`.env\` into the container via stdin JSON. \`SUMMARIZER_*\` keys are not in the allowlist. \`_summarizer.is_enabled()\` reads via \`os.environ.get()\` → empty → False → WebFetch falls back to chunked.

## Fix

Add the seven \`SUMMARIZER_*\` keys to the allowlist. \`agent.py:159\` already promotes secrets to \`os.environ\`, so they become visible to \`_summarizer.py\` automatically. No image rebuild needed (host-side change).

## Test plan

- [x] Syntax check passes
- [ ] Post-merge: restart evoclaw, trigger WebFetch with prompt, confirm \`✨ SUM-OK\` log + main model receives summarizer output