### PR TITLE
fix(discord): close prior Client before reconnect to plug aiohttp leak (#557)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.27.16] — 2026-04-28
+
+### Fixed
+- **Discord channel leaked aiohttp ClientSession on every reconnect failure.** When `discord.com` was network-blocked (SNI filtering observed in this deployment), `connect()` retried 4 times per minute, each call instantiating a new `discord.Client` (which owns an `aiohttp.ClientSession`) without closing the previous one. Accumulated 1790+ "Unclosed client session" errors over multiple days. Fix: close the prior client at the start of `connect()` if one exists. (#557)
+
+### Technical Details
+- **Modified Files**: `host/channels/discord_channel.py`
+- **Image rebuild required**: No (host-side change only)
+- **Breaking Changes**: None.
+
 ## [1.27.15] — 2026-04-27
 
 ### Fixed

--- a/host/channels/discord_channel.py
+++ b/host/channels/discord_channel.py
@@ -118,6 +118,19 @@ class DiscordChannel:
             log.warning("DISCORD_BOT_TOKEN not set — Discord disabled")
             return
 
+        # Issue #557: close any pre-existing client before allocating a new one.
+        # Each discord.Client owns an aiohttp.ClientSession; failed-reconnect
+        # loops were leaking dozens of these sessions per minute on networks
+        # that block discord.com (observed 1790 "Unclosed client session"
+        # errors over multiple days).
+        _old = getattr(self, "_client", None)
+        if _old is not None:
+            try:
+                if not _old.is_closed():
+                    await _old.close()
+            except Exception as _close_exc:
+                log.debug("Discord: error closing prior client: %s", _close_exc)
+
         intents = discord.Intents.default()
         intents.message_content = True
         intents.messages = True


### PR DESCRIPTION
Closes #557

Each `discord_channel.connect()` instantiated a new `discord.Client` (own aiohttp.ClientSession) without closing the previous one. With discord.com SNI-blocked in this deployment, reconnects fired 4× per minute and leaked 4 sessions each cycle — 1790 "Unclosed client session" errors accumulated.

## Fix
Close prior client at start of `connect()`:
```python
_old = getattr(self, '_client', None)
if _old is not None:
    try:
        if not _old.is_closed():
            await _old.close()
    except Exception:
        pass
```

## Test plan
- [x] Syntax check
- [ ] Post-merge: monitor `grep -c 'Unclosed client session'` for 24h, expect ~0 growth even during ongoing Discord outage
