### PR TITLE
fix(host): orphan_cleanup must skip active containers (#565)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.27.20] — 2026-05-07
+
+### Fixed
+- **🚨 ROOT CAUSE: orphan_cleanup_loop killing live containers every 5 minutes (mis-reported as OOM).** `cleanup_orphans` ran `docker rm -f` on every container matching `name=evoclaw-` — including ones still actively running an agent task. With the loop firing every 5 min from `_orphan_cleanup_loop`, any task longer than 5 min got SIGKILL'd, container_runner saw exit 137, mis-attributed it as "OOM-killed (exit 137)", retry storm started. Diagnostic `State.OOMKilled` query (#563) revealed `error: no such object` — container deleted before inspect. Sample timing: container `8bee26eb` ran 47 MEMDEBUG samples ≈ 5min, then died exactly on cleanup tick. **This single bug invalidates 11 prior PRs of Python-side memory fixes** (#539, #540, #542, #544, #545, #547, #548, #551, #553, #554, #557, #559, #561) — they may have been useful hardening but none addressed the actual OOM symptom. Fix: enumerate by name, skip containers in `_active_containers` set, only kill truly orphaned ones from prior crashes. (#565)
+
+### Technical Details
+- **Modified Files**: `host/container_runner.py:cleanup_orphans`
+- **Image rebuild required**: No (host-side change only)
+- **Breaking Changes**: None.
+
 ## [1.27.19] — 2026-05-07
 
 ### Added

--- a/host/container_runner.py
+++ b/host/container_runner.py
@@ -921,13 +921,17 @@ async def run_container_agent(
                         capture_output=True, timeout=5, text=True,
                         creationflags=_NO_WINDOW,
                     )
-                    _docker_state_blob = (_ins.stdout or "").strip()
-                    if "OOMKilled=true" in _docker_state_blob:
+                    _stdout = (_ins.stdout or "").strip()
+                    _stderr = (_ins.stderr or "").strip()
+                    _docker_state_blob = (
+                        f"rc={_ins.returncode} stdout={_stdout!r} stderr={_stderr!r}"
+                    )
+                    if "OOMKilled=true" in _stdout:
                         _true_oom_killed = True
-                    elif "OOMKilled=false" in _docker_state_blob:
+                    elif "OOMKilled=false" in _stdout:
                         _true_oom_killed = False
                 except Exception as _ins_exc:
-                    _docker_state_blob = f"<inspect failed: {_ins_exc}>"
+                    _docker_state_blob = f"<inspect failed: {type(_ins_exc).__name__}: {_ins_exc}>"
 
             if _container_ran:
                 # Log OOM explicitly so operators can act (raise --memory limit)
@@ -1272,15 +1276,31 @@ async def cleanup_orphans() -> None:
     the same name and waste storage.  Use `docker ps -a` to catch all states.
     """
     try:
+        # Issue #565: previously this killed ALL evoclaw-* containers including
+        # running ones, mid-execution.  With cleanup_orphans called every 5 min
+        # by _orphan_cleanup_loop, any agent task >5 min was force-killed and
+        # mis-reported as exit 137 OOM.  This single bug caused 11+ rounds of
+        # fruitless Python-side memory fixes (#539-#561).
+        # Now: enumerate by NAME, skip names currently in _active_containers,
+        # and only force-remove the rest (truly orphaned from prior crashes).
+        async with _get_active_lock():
+            _live_names = set(_active_containers.keys())
+
         # -a: include stopped containers (Exited, Created, etc.) not just running ones.
         # This is critical for post-SIGKILL recovery where --rm never fired.
         proc = await asyncio.create_subprocess_exec(
-            "docker", "ps", "-a", "-q", "--filter", "name=evoclaw-",
+            "docker", "ps", "-a", "--filter", "name=evoclaw-",
+            "--format", "{{.ID}} {{.Names}}",
             stdout=asyncio.subprocess.PIPE,
             creationflags=_NO_WINDOW,
         )
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=15.0)
-        ids = [i for i in out.decode().split() if i]
+        _all = [line.split(" ", 1) for line in out.decode().splitlines() if line.strip()]
+        ids = [cid for cid, name in _all if name not in _live_names]
+        _skipped = [name for cid, name in _all if name in _live_names]
+        if _skipped:
+            log.debug("cleanup_orphans: skipping %d active container(s): %s",
+                      len(_skipped), ", ".join(_skipped))
         if ids:
             rm_proc = await asyncio.create_subprocess_exec(
                 "docker", "rm", "-f", *ids,


### PR DESCRIPTION
Closes #565 — ROOT CAUSE FOUND for OOM saga

`cleanup_orphans` killed ALL evoclaw-* containers every 5 min, including running ones. Any task >5 min got SIGKILL'd, mis-reported as exit 137 OOM. 11 prior PRs (#539-#561) targeted Python memory; none addressed actual symptom.

Confirmed by #563 diagnostic: `docker_inspect: rc=1 stderr='no such object'` — container deleted by cleanup before inspect.

## Fix
`cleanup_orphans` now enumerates name+ID, skips names in `_active_containers`, only kills orphans from prior crashes.

## Test plan
- [x] Syntax check
- [ ] Post-merge: long task (>5 min) completes
- [ ] Log shows `cleanup_orphans: skipping N active container(s)` during active runs