### PR TITLE
feat(self_update): add restart_host tool — plain os.execv (#573)

### DIFF
--- a/container/agent-runner/_registry.py
+++ b/container/agent-runner/_registry.py
@@ -20,7 +20,7 @@ from _tools import (
     tool_send_message, tool_schedule_task, tool_list_tasks,
     tool_cancel_task, tool_pause_task, tool_resume_task,
     tool_run_agent, tool_send_file, tool_start_remote_control,
-    tool_self_update, tool_glob, tool_grep, tool_web_fetch,
+    tool_self_update, tool_restart_host, tool_glob, tool_grep, tool_web_fetch,
     tool_memory_recall, tool_memory_remember,
     _messages_sent_via_tool,
 )
@@ -319,11 +319,22 @@ TOOL_DECLARATIONS = [] if not _GOOGLE_AVAILABLE or types is None else [
     ),
     types.FunctionDeclaration(
         name="mcp__evoclaw__self_update",
-        description="Pull the latest EvoClaw code from git and restart the host process. Use when the user asks to update, upgrade, or restart EvoClaw.",
+        description="Pull the latest EvoClaw code from git, run tests, then restart the host. Use when user asks to UPDATE / 更新 / upgrade / pull new code. NOT for plain restart — use mcp__evoclaw__restart_host for that.",
         parameters=types.Schema(
             type=types.Type.OBJECT,
             properties={
                 "chat_jid": types.Schema(type=types.Type.STRING, description="The chat JID to notify when update is done (auto-detected if omitted)"),
+            },
+            required=[],
+        ),
+    ),
+    types.FunctionDeclaration(
+        name="mcp__evoclaw__restart_host",
+        description="Restart EvoClaw host process WITHOUT pulling new code. Use when user asks to restart / 重啟 / reload .env / unstick. Different from self_update which pulls + tests new code.",
+        parameters=types.Schema(
+            type=types.Type.OBJECT,
+            properties={
+                "chat_jid": types.Schema(type=types.Type.STRING, description="The chat JID to notify when restart is done (auto-detected if omitted)"),
             },
             required=[],
         ),
@@ -380,7 +391,8 @@ OPENAI_TOOL_DECLARATIONS = [
     {"type": "function", "function": {"name": "mcp__evoclaw__send_file", "description": "Send a file to the user. Write the file to /workspace/group/output/ first, then call this tool.", "parameters": {"type": "object", "properties": {"chat_jid": {"type": "string", "description": "The chat JID to send the file to"}, "file_path": {"type": "string", "description": "Absolute container path to the file"}, "caption": {"type": "string", "description": "Optional caption"}}, "required": ["file_path"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__reset_group", "description": "Clear the failure counter for a group, unfreezing it if it was locked in cooldown. Use when a group is stuck and not responding.", "parameters": {"type": "object", "properties": {"jid": {"type": "string", "description": "The JID of the group to reset, e.g. tg:8259652816"}}, "required": ["jid"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__start_remote_control", "description": "Start a Claude Code remote-control session. The host spawns `claude remote-control` and sends the URL back to this chat. Use when the user wants to update code or restart EvoClaw.", "parameters": {"type": "object", "properties": {"chat_jid": {"type": "string"}, "sender": {"type": "string"}}, "required": []}}},
-    {"type": "function", "function": {"name": "mcp__evoclaw__self_update", "description": "Pull the latest EvoClaw code from git and restart the host process. Use when the user asks to update, upgrade, or restart EvoClaw.", "parameters": {"type": "object", "properties": {"chat_jid": {"type": "string"}}, "required": []}}},
+    {"type": "function", "function": {"name": "mcp__evoclaw__self_update", "description": "Pull latest EvoClaw code from git, run tests, then restart host. Use when user asks to UPDATE / 更新 / upgrade / pull new code. NOT for plain restart — use mcp__evoclaw__restart_host.", "parameters": {"type": "object", "properties": {"chat_jid": {"type": "string"}}, "required": []}}},
+    {"type": "function", "function": {"name": "mcp__evoclaw__restart_host", "description": "Restart EvoClaw host process WITHOUT pulling new code. Use when user asks to restart / 重啟 / reload .env / unstick.", "parameters": {"type": "object", "properties": {"chat_jid": {"type": "string"}}, "required": []}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__memory_recall", "description": "Query the agent memory store. Returns each match as id + score + summary (≤200 chars). For full content of one memory, run a more specific query that matches it.", "parameters": {"type": "object", "properties": {"query": {"type": "string", "description": "Natural-language query to search memories"}, "k": {"type": "integer", "description": "Maximum number of memories to return (default 5)"}, "namespace": {"type": "string", "description": "Optional project namespace / scope filter"}, "topic_tag": {"type": "string", "description": "Optional topic tag for future filtering"}}, "required": ["query"]}}},
     {"type": "function", "function": {"name": "mcp__evoclaw__memory_remember", "description": "Store a new memory in the agent memory store so it can be recalled in future sessions.", "parameters": {"type": "object", "properties": {"content": {"type": "string", "description": "Text content to remember"}, "importance": {"type": "number", "description": "Importance weight 0.0-1.0 (default 0.7)"}, "namespace": {"type": "string", "description": "Optional project namespace / scope"}, "topic_tag": {"type": "string", "description": "Optional topic tag"}}, "required": ["content"]}}},
 ]
@@ -405,7 +417,8 @@ CLAUDE_TOOL_DECLARATIONS = [
     {"name": "mcp__evoclaw__send_file", "description": "Send a file to the user. Write the file to /workspace/group/output/ first, then call this tool.", "input_schema": {"type": "object", "properties": {"chat_jid": {"type": "string", "description": "The chat JID to send the file to"}, "file_path": {"type": "string", "description": "Absolute container path to the file"}, "caption": {"type": "string", "description": "Optional caption"}}, "required": ["file_path"]}},
     {"name": "mcp__evoclaw__reset_group", "description": "Clear the failure counter for a group, unfreezing it if it was locked in cooldown. Use when a group is stuck and not responding.", "input_schema": {"type": "object", "properties": {"jid": {"type": "string", "description": "The JID of the group to reset, e.g. tg:8259652816"}}, "required": ["jid"]}},
     {"name": "mcp__evoclaw__start_remote_control", "description": "Start a Claude Code remote-control session. The host spawns `claude remote-control` and sends the URL back to this chat. Use when the user wants to update code or restart EvoClaw.", "input_schema": {"type": "object", "properties": {"chat_jid": {"type": "string"}, "sender": {"type": "string"}}, "required": []}},
-    {"name": "mcp__evoclaw__self_update", "description": "Pull the latest EvoClaw code from git and restart the host process. Use when the user asks to update, upgrade, or restart EvoClaw.", "input_schema": {"type": "object", "properties": {"chat_jid": {"type": "string"}}, "required": []}},
+    {"name": "mcp__evoclaw__self_update", "description": "Pull latest EvoClaw code from git, run tests, then restart host. Use when user asks to UPDATE / 更新 / upgrade / pull new code. NOT for plain restart — use mcp__evoclaw__restart_host.", "input_schema": {"type": "object", "properties": {"chat_jid": {"type": "string"}}, "required": []}},
+    {"name": "mcp__evoclaw__restart_host", "description": "Restart EvoClaw host process WITHOUT pulling new code. Use when user asks to restart / 重啟 / reload .env / unstick.", "input_schema": {"type": "object", "properties": {"chat_jid": {"type": "string"}}, "required": []}},
     {"name": "mcp__evoclaw__memory_recall", "description": "Query the agent memory store. Returns each match as id + score + summary (≤200 chars). For full content of one memory, run a more specific query that matches it.", "input_schema": {"type": "object", "properties": {"query": {"type": "string", "description": "Natural-language query to search memories"}, "k": {"type": "integer", "description": "Maximum number of memories to return (default 5)"}, "namespace": {"type": "string", "description": "Optional project namespace / scope filter"}, "topic_tag": {"type": "string", "description": "Optional topic tag for future filtering"}}, "required": ["query"]}},
     {"name": "mcp__evoclaw__memory_remember", "description": "Store a new memory in the agent memory store so it can be recalled in future sessions.", "input_schema": {"type": "object", "properties": {"content": {"type": "string", "description": "Text content to remember"}, "importance": {"type": "number", "description": "Importance weight 0.0-1.0 (default 0.7)"}, "namespace": {"type": "string", "description": "Optional project namespace / scope"}, "topic_tag": {"type": "string", "description": "Optional topic tag"}}, "required": ["content"]}},
 ]
@@ -530,6 +543,8 @@ def _execute_tool_inner(name: str, args: dict, chat_jid: str) -> str:
         return tool_start_remote_control(args.get("chat_jid", chat_jid), args.get("sender", ""))
     elif name == "mcp__evoclaw__self_update":
         return tool_self_update(args.get("chat_jid", chat_jid))
+    elif name == "mcp__evoclaw__restart_host":
+        return tool_restart_host(args.get("chat_jid", chat_jid))
     elif name == "mcp__evoclaw__memory_recall":
         _mr_query = args.get("query")
         if not isinstance(_mr_query, str):

--- a/container/agent-runner/_tools.py
+++ b/container/agent-runner/_tools.py
@@ -670,6 +670,29 @@ def tool_self_update(chat_jid: str = "") -> str:
         return f"Error: {exc}"
 
 
+def tool_restart_host(chat_jid: str = "") -> str:
+    """Restart the EvoClaw host process WITHOUT pulling new code (Issue #573).
+
+    Use when:
+      * Operator wants to reload .env changes
+      * Channel state is stuck and needs a fresh process
+      * A new agent image was just built and host needs to pick it up
+
+    Different from `self_update` which does git pull + tests.  This just
+    triggers `os.execv()` on the same on-disk code.  No token gate.
+    """
+    effective_jid = chat_jid or _constants._input_chat_jid or ""
+    try:
+        fname = _write_ipc_file(IPC_TASKS_DIR, {
+            "type": "restart_host",
+            "jid": effective_jid,
+        }, suffix="restart-host")
+        _log("📨 IPC", f"type=restart_host jid={effective_jid} → {fname.name}")
+        return "Restart requested — EvoClaw will restart shortly (no code pull)."
+    except Exception as exc:
+        return f"Error: {exc}"
+
+
 def tool_memory_recall(args: dict) -> str:
     """Query the host MemoryBus via IPC and return relevant memories.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.27.24] — 2026-05-08
+
+### Added
+- **`mcp__evoclaw__restart_host` tool — plain os.execv restart without git pull / test gate.** `self_update` requires `SELF_UPDATE_TOKEN` (out-of-band confirmation) which is overkill when operator just wants to reload `.env` changes or unstick channel state. New tool writes `restart.flag`; `main._message_loop` picks it up and triggers the same `os.execv` path as self_update — pm2 sees a stable supervisor PID. No token gate (lower stakes: doesn't pull remote code). Tool descriptions explicitly distinguish 更新 (self_update) from 重啟 (restart_host) so the agent picks the right one. (#573)
+
+### Technical Details
+- **New Files**: none
+- **Modified Files**: `host/main.py` (restart.flag handler in message loop), `host/ipc_watcher.py` (`restart_host` IPC handler), `container/agent-runner/_tools.py` (`tool_restart_host`), `container/agent-runner/_registry.py` (Gemini/OpenAI/Claude declarations + dispatcher)
+- **Image rebuild required**: Yes (container code changed)
+- **Breaking Changes**: None.
+- **Security**: no token gate. If prompt-injection is a concern, set `EVOCLAW_DISABLE_RESTART_TOOL=true` (TODO: not yet implemented — open issue if needed).
+
 ## [1.27.23] — 2026-05-08
 
 ### Added

--- a/host/ipc_watcher.py
+++ b/host/ipc_watcher.py
@@ -628,6 +628,38 @@ async def _handle_ipc(payload: dict, group_folder: str, is_main: bool, route_fn:
         t = _asyncio.create_task(_run_self_update(_su_jid, route_fn))
         t.add_done_callback(_ipc_task_done_callback)
 
+    elif msg_type == "restart_host":
+        # Issue #573: plain os.execv restart (no git pull, no test gate).
+        # Use cases:
+        #   * reload .env changes
+        #   * recover from stuck channel state
+        #   * force-pickup of new image after manual `docker build`
+        # Lower-stakes than self_update: no remote code pulled, only re-runs
+        # the existing on-disk python.  No token gate.
+        _rh_jid = payload.get("jid", "")
+        if not _rh_jid:
+            _rh_groups = db.get_all_registered_groups()
+            _rh_match = next((g for g in _rh_groups if g.get("folder") == group_folder), None)
+            _rh_jid = _rh_match["jid"] if _rh_match else ""
+        async def _do_restart_host():
+            try:
+                if _rh_jid:
+                    await route_fn(_rh_jid, "🔁 EvoClaw 即將重啟（不更新代碼）...")
+                flag = config.DATA_DIR / "restart.flag"
+                await _asyncio.get_running_loop().run_in_executor(
+                    None, lambda: flag.write_text("manual restart_host", encoding="utf-8")
+                )
+                log.info("restart_host: flag written — main loop will os.execv shortly")
+            except Exception as exc:
+                log.error("restart_host: failed to write flag: %s", exc)
+                if _rh_jid:
+                    try:
+                        await route_fn(_rh_jid, f"❌ 重啟失敗：{exc}")
+                    except Exception:
+                        pass
+        t = _asyncio.create_task(_do_restart_host())
+        t.add_done_callback(_ipc_task_done_callback)
+
     else:
         # Unknown IPC message type — log a warning instead of silently ignoring.
         # This aids debugging when a stale container image sends an unrecognised type.

--- a/host/main.py
+++ b/host/main.py
@@ -1127,6 +1127,21 @@ async def _message_loop() -> None:
                     _stop_event.set()
                 break
 
+            # ── Issue #573: plain restart flag (no git pull, no test) ───────
+            # Triggered by `mcp__evoclaw__restart_host` — used to reload .env
+            # changes or recover from stuck channel state without pulling code.
+            # Reuses _self_update_requested + os.execv path so the lifecycle
+            # is identical (pm2 sees one stable supervisor PID).
+            restart_flag = config.DATA_DIR / "restart.flag"
+            if restart_flag.exists():
+                _self_update_requested = True
+                restart_flag.unlink(missing_ok=True)
+                log.info("restart flag detected — initiating graceful restart (no code pull)")
+                _running = False
+                if _stop_event is not None:
+                    _stop_event.set()
+                break
+
             # ── p22c: Drain health monitor alert queue ───────────────────────
             # health_monitor.py pushes (issue_key, message) tuples onto
             # _health_alert_queue; we deliver them here via route_outbound so


### PR DESCRIPTION
Closes #573

New `mcp__evoclaw__restart_host` tool: writes restart.flag → main_loop os.execv. No token gate (no remote code pull). Tool descriptions explicitly distinguish 更新 (self_update) from 重啟 (restart_host).

## Test plan
- [x] Syntax check
- [ ] Post-merge + image rebuild: TG "請重啟後台" triggers restart_host → host restarts within seconds