### PR TITLE
chore(env): close .env.example drift — Env Drift CI now green (#525)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,16 @@
 GOOGLE_API_KEY=your_google_api_key_here
 # GEMINI_MODEL=gemini-2.0-flash
 
+# Anthropic Claude (set either name — ANTHROPIC_API_KEY is auto-aliased to
+# CLAUDE_API_KEY at process start so README_en.md Quick Start works).
+ANTHROPIC_API_KEY=
+CLAUDE_API_KEY=
+
+# OpenAI / OpenAI-compatible endpoints (also used by host/memory/summarizer.py
+# and host/memory/dream_task.py when SUMMARIZER_PROVIDER=openai-compat).
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+
 # NVIDIA NIM — OpenAI-compatible API (get key from https://build.nvidia.com)
 # NIM_API_KEY=nvapi-your_nim_api_key_here
 # NIM_BASE_URL=https://integrate.api.nvidia.com/v1
@@ -35,6 +45,7 @@ TELEGRAM_UPLOAD_TIMEOUT=300
 # Optional: proxy for networks where api.telegram.org is blocked (e.g. some VPS regions)
 # TELEGRAM_PROXY=http://proxy-host:3128
 # TELEGRAM_PROXY=socks5://user:pass@proxy-host:1080
+TELEGRAM_PROXY=
 
 # WhatsApp (Meta Cloud API)
 # ENABLED_CHANNELS=telegram,whatsapp
@@ -56,6 +67,19 @@ SLACK_APP_TOKEN=xapp-your-slack-app-token
 # Discord
 # ENABLED_CHANNELS=telegram,discord
 DISCORD_BOT_TOKEN=your_discord_bot_token_here
+# Comma-separated Discord bot user IDs that are trusted to send commands.
+# DISCORD_TRUSTED_BOT_IDS=123456789012345678,234567890123456789
+DISCORD_TRUSTED_BOT_IDS=
+
+# Matrix (Element / matrix.org / self-hosted)
+# ENABLED_CHANNELS=telegram,matrix
+# Required to use the Matrix channel:
+MATRIX_HOMESERVER=
+MATRIX_USER_ID=
+MATRIX_ACCESS_TOKEN=
+MATRIX_ROOM_ID=
+# Optional: persisted sync token (auto-updated by the channel after first sync)
+MATRIX_SYNC_TOKEN=
 
 # Gmail (OAuth2 — run setup to generate token)
 # ENABLED_CHANNELS=telegram,gmail
@@ -91,20 +115,27 @@ CONTAINER_TMPFS_SIZE=64m
 # Container graceful stop grace period in seconds (BUG-19B-03): gives agent time to
 # flush writes before SIGKILL is sent.  Intentionally short to avoid blocking shutdown.
 CONTAINER_STOP_GRACE_SECS=5
-# Container network mode. Default "none" is most secure (no outbound internet).
-# Set to "bridge" when agents call LLM APIs directly (NIM, OpenAI, Gemini, etc.)
-# CONTAINER_NETWORK=bridge
+# Container network mode. Default "bridge" lets agents call LLM APIs directly.
+# Set to "none" for full network isolation (only works if LLM calls are proxied).
+CONTAINER_NETWORK=bridge
 
 # Polling intervals (milliseconds)
 POLL_INTERVAL=2000
 SCHEDULER_POLL_INTERVAL=60000
 IPC_POLL_INTERVAL=1000
+# Maximum IPC files drained from /workspace/ipc per polling cycle.
+IPC_MAX_FILES_PER_CYCLE=100
 
 # Per-group message rate limiting (sliding window)
 # A group sending more than RATE_LIMIT_MAX_MSGS within RATE_LIMIT_WINDOW_SECS has
 # excess messages dropped to prevent one group from starving others.
 # RATE_LIMIT_MAX_MSGS=20
 # RATE_LIMIT_WINDOW_SECS=60
+
+# Per-sender outbound rate limit (host → channel). Caps how many messages a
+# single sender can push out within the window before extra sends are dropped.
+SENDER_RATE_LIMIT_MAX=5
+SENDER_RATE_LIMIT_WINDOW_SECS=60
 
 # Dashboard (web UI at http://DASHBOARD_HOST:DASHBOARD_PORT)
 DASHBOARD_HOST=127.0.0.1
@@ -120,10 +151,15 @@ WEBPORTAL_HOST=127.0.0.1
 # Health check endpoint (used by load balancers / Docker HEALTHCHECK)
 # HEALTH_PORT=8769
 
+# Heartbeat interval in seconds (default 1800 = 30 min). Set to 0 to disable.
+HEARTBEAT_INTERVAL=1800
+
 # Data directories (optional overrides)
 LOCALAPPDATA=
 DATA_DIR=./data
 STORE_DIR=./store
+# Container-side data root (default /data inside agent containers; read by host/mcp_server.py).
+EVOCLAW_DATA_DIR=
 
 # ── Monitor Group (optional) ──────────────────────────────────────────────────
 # Telegram group JID for error alerts. When set, EvoClaw auto-registers this
@@ -131,28 +167,34 @@ STORE_DIR=./store
 # timeout, Docker issues) to it — in addition to the originating group.
 # Supports agent-initiated reset_group IPC to unfreeze stuck groups.
 # Format: tg:-XXXXXXXXXX (negative ID for Telegram groups)
-# MONITOR_JID=tg:-5182570432
+MONITOR_JID=
 # Easier: send /monitor in the target group — auto-configures without editing .env
-
-# Heartbeat interval in seconds (default 1800 = 30 min). Set to 0 to disable.
-# HEARTBEAT_INTERVAL=1800
 
 # Optional: Discord webhook URL for a second notification channel.
 # EvoClaw will POST error alerts and heartbeat pings to this URL.
 # No Discord bot token needed — just create a webhook in your Discord channel settings.
-# DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN
-
-# Optional: proxy for networks where api.telegram.org is blocked
-# TELEGRAM_PROXY=http://proxy-host:3128
-# TELEGRAM_PROXY=socks5://user:pass@proxy-host:1080
+DISCORD_WEBHOOK_URL=
 
 # ── Database (optional — defaults to SQLite) ──────────────────────────────────
 # By default EvoClaw uses SQLite (no setup needed).
 # To use PostgreSQL, install psycopg2-binary and set DATABASE_URL:
 #   pip install psycopg2-binary
 #   createdb evoclaw
-# DATABASE_URL=postgresql://user:password@localhost:5432/evoclaw
-# DB_PATH=/absolute/path/to/messages.db  # Override SQLite path (defaults to $STORE_DIR/messages.db; only used when DATABASE_URL is unset)
+DATABASE_URL=
+# Override SQLite path (defaults to $STORE_DIR/messages.db; only used when DATABASE_URL is unset)
+DB_PATH=
+# Source SQLite path used by scripts/sqlite_to_pg.py migration. Defaults to
+# $STORE_DIR/messages.db when unset.
+SQLITE_PATH=
+
+# ── Owner / Self-update auth ──────────────────────────────────────────────────
+# Comma-separated platform-verified user IDs allowed to run /update and /restart
+# Telegram slash commands and the `restart_host` IPC. Empty = nobody.
+OWNER_IDS=
+# Shared-secret token required for the legacy agent-dispatched self_update IPC
+# (when the operator types "請更新後台" instead of /update). Leave empty to keep
+# the legacy path disabled and force use of /update.
+SELF_UPDATE_TOKEN=
 
 # ── GitHub (optional) ─────────────────────────────────────────────────────────
 # Required for agent to use git push / gh repo create / gh pr create inside containers.
@@ -162,12 +204,34 @@ STORE_DIR=./store
 # =============================================================================
 # Phase 1: UnifiedClaw WebSocket Bridge
 # =============================================================================
-# Port for WebSocket IPC bridge (Agent Runtime <-> Gateway)
+# Bind host for the WebSocket IPC bridge (Agent Runtime <-> Gateway).
+WS_BRIDGE_HOST=127.0.0.1
+# Port for WebSocket IPC bridge
 # Agent containers connect via: ws://host.docker.internal:$WS_BRIDGE_PORT
 WS_BRIDGE_PORT=8768
+# Shared-secret token required by the WS bridge. Leave empty to disable auth
+# (only safe when WS_BRIDGE_HOST is bound to loopback).
+WS_BRIDGE_TOKEN=
 
-# Groups directory (default: ./groups)
-GROUPS_DIR=groups
+# =============================================================================
+# SDK API (host/sdk_api.py) — REST surface for MCP server bridge
+# =============================================================================
+SDK_API_HOST=127.0.0.1
+SDK_API_PORT=8767
+# Bearer token required by SDK API. Leave empty to require SDK_API_NO_AUTH=1.
+SDK_API_TOKEN=
+# Set to "1" to disable auth (loopback dev only).
+SDK_API_NO_AUTH=
+# URL used by the MCP server (running inside the agent container) to reach the
+# SDK API on the host. Defaults to http://localhost:8767.
+EVOCLAW_SDK_URL=
+
+# =============================================================================
+# Hooks engine (host/hooks_engine.py)
+# =============================================================================
+# Optional path to a hooks config file (JSON). Empty = use the in-repo default
+# at $DATA_DIR/hooks.json.
+EVOCLAW_HOOKS_CONFIG=
 
 # =============================================================================
 # Phase 4C: Multi-instance Leader Election (optional)
@@ -175,11 +239,48 @@ GROUPS_DIR=groups
 # Set LEADER_ELECTION_ENABLED=true when running multiple evoclaw instances
 # so only ONE processes messages at a time. Single-instance deployments are
 # unaffected — leave this false (the default).
-#
-# LEADER_ELECTION_ENABLED=false   # Set to true when running multiple instances
-# LEADER_HEARTBEAT_INTERVAL=10    # Seconds between heartbeats
-# LEADER_LEASE_TIMEOUT=30         # Seconds before lease considered expired
-# INSTANCE_ID=hostname:pid        # Unique ID (auto-detected by default)
+LEADER_ELECTION_ENABLED=false
+LEADER_HEARTBEAT_INTERVAL=10
+LEADER_LEASE_TIMEOUT=30
+# Unique instance ID. Auto-detected as "<hostname>:<pid>" when unset.
+INSTANCE_ID=
+
+# =============================================================================
+# Enterprise connectors (optional)
+# =============================================================================
+# HPC cluster (Slurm/PBS/LSF) — host/enterprise/hpc_connector.py
+HPC_HOST=
+HPC_PARTITION=
+HPC_SCHEDULER=slurm
+HPC_SSH_KEY=
+# Jira — host/enterprise/jira_connector.py
+JIRA_BASE_URL=
+JIRA_EMAIL=
+JIRA_API_TOKEN=
+JIRA_PROJECT=
+# LDAP — host/enterprise/ldap_connector.py
+LDAP_SERVER=
+LDAP_BASE_DN=
+LDAP_BIND_DN=
+LDAP_BIND_PW=
+
+# =============================================================================
+# Auto-update loop (Issue #530, #569, #570)
+# =============================================================================
+# Periodic `git fetch` + test-gated `git pull` + restart. Defaults OFF.
+AUTO_UPDATE_ENABLED=false
+AUTO_UPDATE_INTERVAL_SECS=3600
+AUTO_UPDATE_BRANCH=main
+AUTO_UPDATE_TEST_CMD=pytest -x --timeout=60 -q tests/
+# Test inside a git worktree sandbox before fast-forwarding main (#569). Recommended.
+AUTO_UPDATE_USE_WORKTREE=true
+# Worktree path. Empty = $DATA_DIR/auto_update_worktree.
+AUTO_UPDATE_WORKTREE_DIR=
+# AI auto-patch on worktree test failures (#570). Disabled by default.
+AUTO_UPDATE_AI_FIX_ENABLED=false
+AUTO_UPDATE_AI_FIX_MAX_RETRIES=3
+# When true, AI-patched commits open a PR instead of fast-forwarding inline.
+AUTO_UPDATE_AI_FIX_REQUIRE_HUMAN_APPROVE=true
 
 # ── Summarizer model (Issue #548) ─────────────────────────────────────────────
 # Optional cheap secondary model used by WebFetch (and other large-output tools)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.27.29] — 2026-05-11
+
+### Fixed
+- **`.env.example` drift — `Env Drift` CI now green.** The `envdrift` workflow (`github:jszzr/envdrift#v0.1.0`) had been failing on every push to main for ~6 weeks (since #512), training reviewers to ignore CI. Drift report listed **57 missing keys** and **13 unused keys**. Manual audit of every entry against `host/` reads: every "Missing" var has a real read site (4 LLM providers, 10 `AUTO_UPDATE_*` knobs, enterprise connectors, leader election, SDK API, WS bridge, etc.); 12 of 13 "Unused" vars are scanner blind-spots (read via `read_env_file([...])` helper or `_env_int()` wrapper rather than direct `os.environ.get()`); only `GROUPS_DIR` was truly dead (hard-coded `BASE_DIR / "groups"` in `host/config.py:22`). (#525)
+
+### Technical Details
+- **Added to `.env.example`**: `ANTHROPIC_API_KEY`, `CLAUDE_API_KEY`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `TELEGRAM_PROXY`, `DISCORD_TRUSTED_BOT_IDS`, `DISCORD_WEBHOOK_URL`, `MATRIX_HOMESERVER`, `MATRIX_USER_ID`, `MATRIX_ACCESS_TOKEN`, `MATRIX_ROOM_ID`, `MATRIX_SYNC_TOKEN`, `IPC_MAX_FILES_PER_CYCLE`, `SENDER_RATE_LIMIT_MAX`, `SENDER_RATE_LIMIT_WINDOW_SECS`, `HEARTBEAT_INTERVAL`, `MONITOR_JID`, `EVOCLAW_DATA_DIR`, `EVOCLAW_HOOKS_CONFIG`, `EVOCLAW_SDK_URL`, `OWNER_IDS`, `SELF_UPDATE_TOKEN`, `DATABASE_URL`, `DB_PATH`, `SQLITE_PATH`, `WS_BRIDGE_HOST`, `WS_BRIDGE_TOKEN`, `SDK_API_HOST`, `SDK_API_PORT`, `SDK_API_TOKEN`, `SDK_API_NO_AUTH`, `LEADER_ELECTION_ENABLED`, `LEADER_HEARTBEAT_INTERVAL`, `LEADER_LEASE_TIMEOUT`, `INSTANCE_ID`, `HPC_HOST`, `HPC_PARTITION`, `HPC_SCHEDULER`, `HPC_SSH_KEY`, `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, `JIRA_PROJECT`, `LDAP_SERVER`, `LDAP_BASE_DN`, `LDAP_BIND_DN`, `LDAP_BIND_PW`, `CONTAINER_NETWORK`, `AUTO_UPDATE_ENABLED`, `AUTO_UPDATE_INTERVAL_SECS`, `AUTO_UPDATE_BRANCH`, `AUTO_UPDATE_TEST_CMD`, `AUTO_UPDATE_USE_WORKTREE`, `AUTO_UPDATE_WORKTREE_DIR`, `AUTO_UPDATE_AI_FIX_ENABLED`, `AUTO_UPDATE_AI_FIX_MAX_RETRIES`, `AUTO_UPDATE_AI_FIX_REQUIRE_HUMAN_APPROVE`.
+- **Removed from `.env.example`**: `GROUPS_DIR` (no env read — config.py:22 hard-codes `BASE_DIR / "groups"`).
+- **Kept 12 scanner false positives**: `TELEGRAM_BOT_TOKEN`, `WHATSAPP_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `DISCORD_BOT_TOKEN` (all read via `read_env_file([...])` in channel files), `POLL_INTERVAL`, `SCHEDULER_POLL_INTERVAL`, `IPC_POLL_INTERVAL`, `MAX_CONCURRENT_CONTAINERS`, `CONTAINER_STOP_GRACE_SECS` (all read via `_env_int()` wrapper in `host/config.py`). Without `--strict`, envdrift exits 0 on unused-only drift, so the workflow goes green even with these documented knobs present.
+- **Verification**: `npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include host` → `No missing keys`, exit code 0.
+- **Modified Files**: `.env.example`
+- **Image rebuild required**: No (config docs only)
+- **Breaking Changes**: None.
+
 ## [1.27.28] — 2026-05-08
 
 ### Removed


### PR DESCRIPTION
## Summary
- Audited every `envdrift` finding against `host/` reads.
- **57 Missing** → all real, added to `.env.example` with documented defaults, grouped by section.
- **13 Unused** → 12 are scanner blind-spots (indirect read via `read_env_file([...])` in channels or `_env_int()` wrapper in `host/config.py`); only `GROUPS_DIR` was truly dead (`host/config.py:22` hard-codes `BASE_DIR / "groups"`). Removed `GROUPS_DIR`; kept the 12 false positives as documented knobs.
- `envdrift` exits 0 without `--strict`, so unused-only drift no longer fails CI.

Local verification:
```
$ npx -y github:jszzr/envdrift#v0.1.0 . --example .env.example --include host
Scanned 70 files
No missing keys in .env.example.

Unused in .env.example (not found in source):
  - CONTAINER_STOP_GRACE_SECS   (read via _env_int)
  - DISCORD_BOT_TOKEN           (read via read_env_file)
  - IPC_POLL_INTERVAL           (read via _env_int)
  - MAX_CONCURRENT_CONTAINERS   (read via _env_int)
  - POLL_INTERVAL               (read via _env_int)
  - SCHEDULER_POLL_INTERVAL     (read via _env_int)
  - SLACK_APP_TOKEN             (read via read_env_file)
  - SLACK_BOT_TOKEN             (read via read_env_file)
  - TELEGRAM_BOT_TOKEN          (read via read_env_file)
  - WHATSAPP_PHONE_NUMBER_ID    (read via read_env_file)
  - WHATSAPP_TOKEN              (read via read_env_file)
  - WHATSAPP_VERIFY_TOKEN       (read via read_env_file)
$ echo $?
0
```

Closes #525.

## Test plan
- [x] Local envdrift exits 0
- [x] All "Missing" vars confirmed via grep against host/
- [x] `GROUPS_DIR` confirmed dead at `host/config.py:22`
- [ ] PR `Env Drift` job goes from fail → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)