### PR TITLE
fix(host): OOM mitigations A+C for #538 (tmpfs default + oom_score_adj)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,8 +110,11 @@ CONTAINER_CPUS=1.0
 # Container log size cap (BUG-19B-01): prevents Docker json-file logs from filling the host disk.
 CONTAINER_LOG_MAX_SIZE=10m
 CONTAINER_LOG_MAX_FILES=2
-# Container /tmp tmpfs size (BUG-19B-02): bounds temp file disk usage per container.
-CONTAINER_TMPFS_SIZE=64m
+# Container /tmp tmpfs size (BUG-19B-02; #538 mitigation A): bounds temp file
+# disk usage per container.  Default lowered 64m → 16m — the reservation itself
+# counts against cgroup memory even when /tmp is empty.  Raise if workloads
+# write large /tmp artifacts.
+CONTAINER_TMPFS_SIZE=16m
 # Container graceful stop grace period in seconds (BUG-19B-03): gives agent time to
 # flush writes before SIGKILL is sent.  Intentionally short to avoid blocking shutdown.
 CONTAINER_STOP_GRACE_SECS=5

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.27.30] — 2026-05-14
+
+### Changed
+- **OOM headroom mitigation A (#538): lowered `CONTAINER_TMPFS_SIZE` default `64m → 16m`.** The tmpfs reservation itself counts against the container's cgroup memory budget even when `/tmp` is empty, so the smaller default reclaims ~48 MB of headroom per container with no functional impact for normal agent workloads (entrypoint.sh writes a single ~few-KB `/tmp/input.json`). Operators with workloads that write large `/tmp/*` artifacts can raise the value in `.env`. Existing deployments that already set `CONTAINER_TMPFS_SIZE=64m` in their `.env` keep their current behaviour.
+
+### Added
+- **OOM headroom mitigation C (#538): set `--oom-score-adj=500` on every agent container.** When the host as a whole is under memory pressure, the kernel now prefers to kill the agent container's processes rather than host processes. Does not change the in-cgroup OOM rate (`CONTAINER_MEMORY` still bounds the agent's own budget); only adds a safety net so escalating memory pressure cannot take down the host process.
+
+### Technical Details
+- **Modified Files**: `host/config.py:140` (default lowered + comment updated), `host/container_runner.py:670` (new `--oom-score-adj` flag), `.env.example` (documentation updated).
+- **Image rebuild required**: No (host-side change only — Docker flag goes on `docker run`).
+- **Breaking Changes**: None. Operators with custom `CONTAINER_TMPFS_SIZE` in `.env` see no change; new installs get the lower default.
+- **Mitigation B (#538) note**: the issue listed "Skip `:ro` full-project mount for regular groups" as a candidate. Inspected `host/container_runner.py:315-348` — this is already the case. Non-main groups mount only their own folder + `global/:ro` + sessions + ipc + dynamic_tools; they do not mount the project. No code change needed for B.
+- **Not included here**: mitigations D–H from #538 (graceful degradation, long-lived worker pool, nsjail replacement, dynamic budget). Those are larger architectural moves; A+C are the low-risk first batch.
+
 ## [1.27.29] — 2026-05-11
 
 ### Fixed

--- a/host/config.py
+++ b/host/config.py
@@ -133,11 +133,15 @@ CONTAINER_PIDS_LIMIT: int = _env_int("CONTAINER_PIDS_LIMIT", 256)
 # Format: "<N>m" for megabytes (e.g. "10m").
 CONTAINER_LOG_MAX_SIZE: str = os.environ.get("CONTAINER_LOG_MAX_SIZE", "10m")
 CONTAINER_LOG_MAX_FILES: str = os.environ.get("CONTAINER_LOG_MAX_FILES", "2")
-# CONTAINER_TMPFS_SIZE (BUG-19B-02):
+# CONTAINER_TMPFS_SIZE (BUG-19B-02 + #538 mitigation A):
 # Size of the tmpfs mounted at /tmp inside each container.  Bounds the amount
 # of host memory a container may consume via temporary files (including the
-# /tmp/input.json written by entrypoint.sh).  Default: 64m.
-CONTAINER_TMPFS_SIZE: str = os.environ.get("CONTAINER_TMPFS_SIZE", "64m")
+# /tmp/input.json written by entrypoint.sh).  Default lowered 64m → 16m as
+# part of the OOM headroom recovery (#538): the tmpfs reservation itself
+# counts against the container's cgroup memory budget even when /tmp is
+# empty, so the smaller default reclaims ~48 MB of headroom per container.
+# Raise back to 64m or higher if a workload writes large /tmp/* artifacts.
+CONTAINER_TMPFS_SIZE: str = os.environ.get("CONTAINER_TMPFS_SIZE", "16m")
 # CONTAINER_STOP_GRACE_SECS (BUG-19B-03):
 # Seconds to wait for SIGTERM to cleanly stop a container before Docker issues
 # SIGKILL.  Gives the agent time to flush open file writes and close IPC files

--- a/host/container_runner.py
+++ b/host/container_runner.py
@@ -668,6 +668,16 @@ async def run_container_agent(
     # runaway agent can fill the host's overlay storage via the container layer.
     # Mount a dedicated tmpfs so /tmp is memory-backed and size-limited.
     cmd += ["--tmpfs", f"/tmp:size={config.CONTAINER_TMPFS_SIZE},mode=1777"]
+    # ── #538 mitigation C: protect host from OOM-kill in container's favour ──
+    # Set the per-container oom_score_adj to a positive value so the kernel
+    # prefers to kill the container's processes when the host as a whole is
+    # under memory pressure.  This does NOT reduce the agent's own cgroup OOM
+    # rate (its in-cgroup processes still hit CONTAINER_MEMORY first), but
+    # ensures that if memory pressure escalates to the host level the agent
+    # container is sacrificed before the host process.  Value 500 is the
+    # midpoint of the kernel's [-1000, 1000] range — "noticeably more
+    # killable than host processes" without being a forced kill.
+    cmd += ["--oom-score-adj", "500"]
     if uid is not None and gid is not None:
         cmd += ["--user", f"{uid}:{gid}"]
     cmd += [


### PR DESCRIPTION
## Summary

First-batch low-risk OOM mitigations from #538 (A + C). Skips D–H — those are larger architectural moves.

### A — `CONTAINER_TMPFS_SIZE` default 64m → 16m
The tmpfs reservation itself counts against the container's cgroup memory budget even when `/tmp` is empty. Real `/tmp` workload is one `entrypoint.sh`-written `/tmp/input.json` of a few KB. The smaller default reclaims **~48 MB headroom per container** at zero functional cost for normal agent workloads. Operators with heavy `/tmp` writes can raise the value in `.env`.

### C — `--oom-score-adj=500` on every agent container
When the host is under memory pressure as a whole, the kernel now prefers to kill the agent container's processes over host processes. **Does not change the in-cgroup OOM rate** (`CONTAINER_MEMORY` still bounds the agent's own budget); only adds a safety net so escalating memory pressure cannot take down the host process.

### B (not changed) — already implemented
Issue #538 listed "Skip `:ro` full-project mount for regular groups" as a candidate. Reviewing `host/container_runner.py:315-348` shows this is already the case: non-main groups mount only their own folder + `global/:ro` + sessions + ipc + dynamic_tools. No project mount, no page-cache pressure from a `:ro` 8 MB source tree. Documented in CHANGELOG as a no-op for posterity.

## Files

| File | Change |
|---|---|
| `host/config.py:140` | Default `64m → 16m`, comment updated with rationale |
| `host/container_runner.py:670` | New `--oom-score-adj 500` flag on `docker run` |
| `.env.example` | Doc + default `64m → 16m` |
| `docs/CHANGELOG.md` | Entry `1.27.30` |

## Test plan
- [x] Local file edits compile-clean (`config.py` import works)
- [x] `git diff` reviewed
- [ ] Post-merge: tail container start logs, confirm `--oom-score-adj 500` appears in the `docker run` argv (host log)
- [ ] Post-merge: a few real turns through the agent, look for OOM frequency drop in `host/logs/*` over a 24h window
- [ ] If OOM frequency does not improve, escalate to mitigation D (graceful degradation / agent self-throttle) per #538

Refs #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)