### PR TITLE
fix(host): MEMORY.md auto-write extracts last <message> body, not raw XML prefix (#583)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.27.31] — 2026-05-14
+
+### Fixed
+- **`MEMORY.md` host auto-write fallback no longer writes raw XML prompt prefix (#583).** Previously `host/container_runner.py:1083` sliced `(prompt or "")[:80]` to summarise the just-completed session.  `prompt` is the full serialised XML payload (`<context>...<messages><message ...>...`), so every fallback entry landed inside the opening tags and produced identical-looking garbage such as `[2026-05-12] [auto] Task: <context timezone="UTC" /> <messages> <message sender="Ke Ma" time="May 12, 2026. Result: success.` — dozens of repeats accumulated in long-running groups' `MEMORY.md`.  Fix: extract the last `<message>...</message>` body via regex, strip nested tags, then truncate.  Existing polluted entries are not auto-scrubbed (separate clean-up script tracked outside this PR).
+
+### Technical Details
+- **Modified Files**: `host/container_runner.py` (auto-write fallback block, ~line 1090).
+- **Image rebuild required**: No (host-side change only).
+- **Breaking Changes**: None.  Output shape (`[YYYY-MM-DD] [auto] Task: <text>. Result: success.`) unchanged — only the `<text>` source is fixed.
+- **Test coverage**: no new test added; the regex is exercised once per successful container run.  A follow-up unit test for `_prompt_preview` extraction is welcome.
+
 ## [1.27.30] — 2026-05-14
 
 ### Changed

--- a/host/container_runner.py
+++ b/host/container_runner.py
@@ -1090,7 +1090,22 @@ async def run_container_agent(
             _mem_mtime = _host_memory_path.stat().st_mtime if _host_memory_path.exists() else 0.0
             if _mem_mtime < t0:
                 _date_str = _dt.datetime.now().strftime("%Y-%m-%d")
-                _prompt_preview = (prompt or "")[:80].replace("\n", " ") if prompt else "(no prompt)"
+                # #583 fix: previously sliced (prompt or "")[:80], which lands inside
+                # the wrapping <context ...><messages><message ...> tags and writes
+                # XML garbage like `<context timezone="UTC" /> <messages> <message
+                # sender="..." time="May 12, 2026,` into MEMORY.md.  Extract the
+                # last <message>...</message> body (the most recent user turn) and
+                # strip nested tags before truncating.
+                _last_msg_match = re.findall(
+                    r"<message[^>]*>(.*?)</message>",
+                    prompt or "",
+                    flags=re.DOTALL,
+                )
+                _last_msg = _last_msg_match[-1] if _last_msg_match else ""
+                _last_msg = re.sub(r"<[^>]+>", "", _last_msg).strip()
+                _prompt_preview = (
+                    _last_msg[:80].replace("\n", " ") if _last_msg else "(no user message)"
+                )
                 _auto_entry = f"\n[{_date_str}] [auto] Task: {_prompt_preview}. Result: success.\n"
                 # p17c BUG-FIX (LOW): open() + write() are blocking syscalls that
                 # can stall the event loop on a slow filesystem (NFS, overlayfs,


### PR DESCRIPTION
## Summary

`host/container_runner.py:1083` previously did `(prompt or \"\")[:80]` for the fallback `MEMORY.md` entry written when the agent didn't update its own memory. `prompt` is the full XML payload (`<context>...<messages><message ...>...`), so every entry landed inside the opening tags and produced garbage like:

```
[2026-05-12] [auto] Task: <context timezone=\"UTC\" /> <messages> <message sender=\"...\" time=\"May 12, 2026. Result: success.
```

Dozens of these accumulated in long-running groups' `MEMORY.md`, polluting both human readers and the next agent turn (which re-ingests `MEMORY.md`).

## Fix

Extract the last `<message>...</message>` body via regex, strip nested tags, then truncate to 80 chars. Output shape unchanged (`[YYYY-MM-DD] [auto] Task: <text>. Result: success.`).

```python
_last_msg_match = re.findall(
    r\"<message[^>]*>(.*?)</message>\",
    prompt or \"\",
    flags=re.DOTALL,
)
_last_msg = _last_msg_match[-1] if _last_msg_match else \"\"
_last_msg = re.sub(r\"<[^>]+>\", \"\", _last_msg).strip()
_prompt_preview = (
    _last_msg[:80].replace(\"\n\", \" \") if _last_msg else \"(no user message)\"
)
```

## Why this matters

- Pollutes `MEMORY.md` with XML noise that compounds over time.
- Bloats the next prompt (`MEMORY.md` is part of the working set), wasting tokens and amplifying #538 OOM pressure.
- Confuses the agent's own introspection — see companion issue #586 (introspection-OOM loop reading mangled MEMORY).

## Test plan

- [x] `git diff` reviewed — single regex-extract block, no behaviour change beyond substring source
- [x] `re` module already imported at `host/container_runner.py:7`
- [ ] Post-merge: trigger a session that does **not** update `MEMORY.md` via tool calls, confirm the fallback entry contains the actual user message text rather than XML

Closes #583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)