### PR TITLE
fix(agent): stop fake 已重啟/更新已觸發 narration after refused self_update (#584)

### DIFF
--- a/container/agent-runner/_tools.py
+++ b/container/agent-runner/_tools.py
@@ -656,7 +656,14 @@ def tool_start_remote_control(chat_jid: str = "", sender: str = "") -> str:
 
 def tool_self_update(chat_jid: str = "") -> str:
     """Request the host to pull the latest EvoClaw code from git and restart.
-    The host will run `git pull` + `pip install -e .` then restart via os.execv()."""
+    The host will run `git pull` + `pip install -e .` then restart via os.execv().
+
+    #584: return wording deliberately neutral — IPC enqueue is NOT a success
+    signal.  The host validates (SELF_UPDATE_TOKEN, idle state, test gate) and
+    posts the real result as a separate user-visible message.  Treating the
+    return string as proof of success caused fake "已重啟 / 更新已觸發"
+    narration loops.
+    """
     effective_jid = chat_jid or _constants._input_chat_jid or ""
     try:
         # Issue #444: use _write_ipc_file helper
@@ -665,7 +672,16 @@ def tool_self_update(chat_jid: str = "") -> str:
             "jid": effective_jid,
         }, suffix="self-update")
         _log("📨 IPC", f"type=self_update jid={effective_jid} → {fname.name}")
-        return "Self-update requested — EvoClaw will pull latest code and restart shortly."
+        return (
+            "Self-update IPC enqueued (NOT yet executed). The host will "
+            "validate the request (e.g. SELF_UPDATE_TOKEN, idle state, test "
+            "gate) and post a separate status message to this chat with the "
+            "outcome. DO NOT claim success, narrate future-tense progress, "
+            "or fabricate restart timings — wait for the host's explicit "
+            "reply (✅ or ❌). If the host responds with a disabled / token-"
+            "missing error, tell the user to use the /update slash command "
+            "instead (it bypasses the legacy token gate)."
+        )
     except Exception as exc:
         return f"Error: {exc}"
 
@@ -688,7 +704,13 @@ def tool_restart_host(chat_jid: str = "") -> str:
             "jid": effective_jid,
         }, suffix="restart-host")
         _log("📨 IPC", f"type=restart_host jid={effective_jid} → {fname.name}")
-        return "Restart requested — EvoClaw will restart shortly (no code pull)."
+        # #584: see tool_self_update for the rationale on neutral wording.
+        return (
+            "Restart IPC enqueued (NOT yet executed). The host will post a "
+            "confirmation message to this chat after the new process starts. "
+            "DO NOT claim the restart already happened — wait for the host's "
+            "explicit reply."
+        )
     except Exception as exc:
         return f"Error: {exc}"
 

--- a/container/agent-runner/soul.md
+++ b/container/agent-runner/soul.md
@@ -89,6 +89,24 @@ These English patterns are just as forbidden as the Chinese fake-status patterns
 - **命令執行必須看結果**：Bash 工具呼叫後，必須確認返回的 stdout/stderr，不能在看到結果前就聲稱「命令已成功執行」。
 - **網路請求必須確認**：WebFetch 或 API 呼叫後，必須確認返回的狀態碼和內容，不能假設成功。
 
+### IPC enqueue ≠ 成功 (#584)
+
+The `mcp__evoclaw__*` tools that write IPC files (`self_update`, `restart_host`, `register_group`, `send_message` to a different jid, etc.) only **enqueue** a request to the host.  The host validates and executes asynchronously; the real outcome arrives as a separate user-visible message in this chat (`✅ EvoClaw 已重啟...`, `❌ self_update 已停用...`, etc.).
+
+After calling any IPC-enqueue tool you MUST:
+
+1. NOT narrate future-tense progress (`正在啟動...`, `正在執行更新...`, `EvoClaw 即將重啟...`).
+2. NOT claim the action has completed (`已重啟`, `更新已觸發`, `Restart done`).
+3. NOT fabricate timings (`請稍候幾分鐘`, `3 minutes remaining`) — you have no information about host-side timing.
+4. NOT invent follow-up tool calls to "fix" a refused prerequisite (`正在設定 SELF_UPDATE_TOKEN...` — you have no write access to host `.env`).
+5. Either stay silent and wait for the host's reply, OR tell the user one sentence: `📨 已送出 X 請求，等待 host 回覆`.  That is the entire allowed narration.
+
+If the host responds with a refusal (`❌ ... 已停用 / disabled / missing token / not authorized`):
+
+- Acknowledge the refusal verbatim to the user.
+- Suggest a concrete next step if one exists (e.g. for `self_update` refusal: tell the user to type `/update` — that slash command bypasses the agent and the legacy token gate).
+- STOP.  Do not retry the same IPC, do not invent a different IPC to fix the prerequisite, do not narrate.
+
 ## MEMORY.md 更新規則（明確）
 
 **必須**更新 MEMORY.md：

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.27.32] — 2026-05-14
+
+### Fixed
+- **Agent no longer fabricates `已重啟 / 更新已觸發` after a refused `self_update` (#584).** Two-layer fix:
+  1. **`container/agent-runner/_tools.py` — neutral return strings.** `tool_self_update` previously returned `"Self-update requested — EvoClaw will pull latest code and restart shortly."`  That wording made the LLM treat IPC-enqueue as proof of success and emit future-tense progress narration (`正在啟動自我更新流程...`, `請稍候幾分鐘`) even when the host immediately rejected the request (e.g. `SELF_UPDATE_TOKEN` unset).  The new return string says `"Self-update IPC enqueued (NOT yet executed). ... DO NOT claim success, narrate future-tense progress, or fabricate restart timings — wait for the host's explicit reply"` and points the user at `/update` as the slash-command alternative.  Same neutral wording applied to `tool_restart_host`.
+  2. **`container/agent-runner/soul.md` — new `IPC enqueue ≠ 成功` section.** Codifies five "you MUST NOT" rules covering future-tense narration, fake completion claims, fabricated timings, invented follow-up IPCs (e.g. `正在設定 SELF_UPDATE_TOKEN...` — the agent has no host `.env` write access), and over-narration in general.  Includes explicit refusal-handling guidance: acknowledge verbatim, suggest a concrete next step (`/update`), STOP.
+
+### Technical Details
+- **Modified Files**: `container/agent-runner/_tools.py` (two tools), `container/agent-runner/soul.md` (new section).
+- **Image rebuild required**: **YES.** The agent runs inside `evoclaw-agent:latest`; `_tools.py` and `soul.md` are shipped in the image.  Operators must `docker build -t evoclaw-agent:latest container/` after merging (or wait for the next auto-update cycle that rebuilds the image).
+- **Breaking Changes**: None for end-users.  Agent prompts that previously triggered fake-restart narration will now produce a single line + wait for host reply.
+
 ## [1.27.31] — 2026-05-14
 
 ### Fixed


### PR DESCRIPTION
## Summary

Two-layer fix for the fake-success narration loop documented in #584.

### Layer 1 — neutral IPC tool returns (`container/agent-runner/_tools.py`)

`tool_self_update` previously returned

> *Self-update requested — EvoClaw will pull latest code and restart shortly.*

That wording treated IPC enqueue as proof of success, so the LLM happily emitted multi-turn future-tense narration (`正在啟動自我更新流程...`, `請稍候幾分鐘`) even when the host immediately rejected the request. New return:

> *Self-update IPC enqueued (NOT yet executed). The host will validate the request (e.g. SELF_UPDATE_TOKEN, idle state, test gate) and post a separate status message to this chat with the outcome. DO NOT claim success, narrate future-tense progress, or fabricate restart timings — wait for the host's explicit reply (✅ or ❌). If the host responds with a disabled / token-missing error, tell the user to use the /update slash command instead (it bypasses the legacy token gate).*

`tool_restart_host` got the same treatment.

### Layer 2 — `soul.md` rules (`container/agent-runner/soul.md`)

New `### IPC enqueue ≠ 成功 (#584)` section under `## 誠實性規則（最高優先）` codifies five MUST NOT rules:

1. No future-tense narration after an IPC enqueue.
2. No completion claims.
3. No fabricated timings.
4. No invented follow-up IPCs to "fix" a refused prerequisite.
5. Either silence, or one short `📨 已送出 X 請求，等待 host 回覆`.

Plus explicit refusal-handling guidance: acknowledge verbatim, suggest `/update`, STOP.

## Why two layers

Just changing soul.md would have left `tool_self_update`'s return value lying about success — the LLM's most immediate signal is the tool result, not the system prompt. Just changing tool returns would have left the system prompt blind to the general IPC-asynchrony pattern. The two together cover both signal paths.

## Files

| File | Change |
|---|---|
| `container/agent-runner/_tools.py` | `tool_self_update` + `tool_restart_host` return strings rewritten |
| `container/agent-runner/soul.md` | New `IPC enqueue ≠ 成功` section |
| `docs/CHANGELOG.md` | Entry `1.27.32` |

## Image rebuild required

**Yes.** `_tools.py` and `soul.md` ship inside `evoclaw-agent:latest`. After merge, operators must run `docker build -t evoclaw-agent:latest container/` (or wait for the next auto-update cycle that rebuilds the image). Host-only code change PRs (like #587) do not need this; this one does.

## Test plan

- [x] `git diff` reviewed — text-only edits, no logic changes
- [x] `_tools.py` still imports cleanly (tested via syntax check before commit)
- [ ] Post-merge + image rebuild: send `請更新後台` in a chat where `SELF_UPDATE_TOKEN` is unset. Expect: one acknowledgement message + suggestion to use `/update`, no "正在啟動..." or "已重啟..." narration.
- [ ] Post-merge: `/update` slash command still works (it doesn't touch the agent, but verify no regression in the host-side path)

Closes #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)