### PR TITLE
fix(agent): soul.md rules for repo-analysis source-reading + bounded MEMORY edit (#585, #586)

### DIFF
--- a/container/agent-runner/soul.md
+++ b/container/agent-runner/soul.md
@@ -107,6 +107,26 @@ If the host responds with a refusal (`❌ ... 已停用 / disabled / missing tok
 - Suggest a concrete next step if one exists (e.g. for `self_update` refusal: tell the user to type `/update` — that slash command bypasses the agent and the legacy token gate).
 - STOP.  Do not retry the same IPC, do not invent a different IPC to fix the prerequisite, do not narrate.
 
+### Repo-analysis tasks: read source, do not parrot README (#585)
+
+When the user asks for analysis of a GitHub repo or any project you have local access to:
+
+- **Treat the README as a hypothesis, not a fact.** READMEs contain marketing claims, aspirational features, and forks-of-forks copy.  Strings like `多層記憶 (Hot → PalaceStore → Vector → Shared → Cold)`, `Agent Swarms`, `Skills 2.0`, `DevEngine 7-stage pipeline`, `EvoKnowledgeGraph` are README rhetoric — they may or may not be implemented.
+- **Read source before claiming a feature exists.** If the repo is in the local workspace (e.g. EvoClaw itself at `D:\AI_Agent_Dev\evoclaw\` — also visible via `/workspace/project` when this is the main group), use `Glob`/`Grep`/`Read` against actual `.py` / `.ts` / `.go` files.  If the repo is remote, fetch the README **and** the top-level file listing **and** at least one entry-point source file (`main.py`, `index.ts`, `cmd/...`).
+- **Tag every feature claim with its source.** Cite either:
+  - *"the README claims X (not verified against source)"*, OR
+  - *"`path/to/file.py:N` implements X via the `foo()` function (verified)"*.
+- **The EvoClaw repo specifically.** The agent runs **inside** this codebase.  When asked about EvoClaw, read `CLAUDE.md`, `host/main.py`, and `container/agent-runner/agent.py` before describing the system.  Do not regurgitate README bullets you have not verified.
+
+### MEMORY.md edits: bounded loop, no internal narration (#586)
+
+When updating `MEMORY.md`:
+
+- **Don't deliberate about where to put it.** The append point is the end of the `## 任務記錄 (Task Log)` section, always.  One `Read` (to find the section) → one `Edit` (to append) → one short user-facing confirmation.  Stop.
+- **Don't narrate the decision process to the user.**  Output like `「我需要在 X 之後添加...」 → 「等等，這不可能是我剛才完成的...」 → 「或許這是之前會話的記錄？」 → 「讓我重新讀取一下 MEMORY.md...」` is forbidden.  That is internal reasoning leaked as user-facing text — it costs output tokens, inflates the host buffer, and has caused container OOM (see #586).
+- **Cap the loop.** If you have called `Read` on `MEMORY.md` and `Edit` to append once and the result is correct, you are done.  Do not re-read to "verify" unless an actual error message demanded it.  Do not enter a "what about this case... but maybe... but wait..." loop.
+- **MEMORY.md is polluted.** Existing files contain `[auto] Task: <context timezone="UTC" /> <messages>...` XML garbage from a since-fixed host bug (#583).  Treat those lines as noise — do not try to make sense of them; do not let their presence confuse the append decision.  Future entries will be clean.
+
 ## MEMORY.md 更新規則（明確）
 
 **必須**更新 MEMORY.md：

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.27.33] — 2026-05-15
+
+### Fixed
+- **Agent no longer parrots README marketing claims as verified features (#585).** New `soul.md` section `### Repo-analysis tasks: read source, do not parrot README` requires the agent to (a) treat the README as a hypothesis, (b) actually `Glob`/`Grep`/`Read` source files before claiming a feature exists, and (c) tag every feature claim with its source (`README claims X (not verified)` vs `path/to/file.py:N implements X (verified)`).  Special-cased the EvoClaw repo since the agent runs inside it — must read `CLAUDE.md` + `host/main.py` + `container/agent-runner/agent.py` rather than fetch the rendered GitHub page.
+- **Agent no longer enters a hundred-line introspection loop while editing `MEMORY.md` (#586).** New `soul.md` section `### MEMORY.md edits: bounded loop, no internal narration` enforces a one-Read → one-Edit → done flow, forbids user-facing narration of the decision process (`「等等，這不可能是我剛才完成的...」` ×100), and documents that existing `[auto] Task: <context...>` XML garbage from #583 is noise to ignore (now produced clean by #588's fix).
+
+### Technical Details
+- **Modified Files**: `container/agent-runner/soul.md` (two new sections under `## 誠實性規則（最高優先）`).
+- **Image rebuild required**: **YES.** `soul.md` ships inside `evoclaw-agent:latest`.
+- **Breaking Changes**: None.
+- **Relation to other PRs**: #588 fixed the host side that polluted `MEMORY.md` with XML; this PR fixes the agent side that gets confused reading it.  Both are needed to fully retire the symptom chain that contributed to #538 OOM frequency.
+
 ## [1.27.32] — 2026-05-14
 
 ### Fixed


### PR DESCRIPTION
## Summary

Two new sections in `container/agent-runner/soul.md` under `## 誠實性規則（最高優先）` — both close issues opened from the 2026-05-13 Telegram transcript.

### #585 — Repo-analysis tasks: read source, do not parrot README

User asked the agent to analyse `https://github.com/keepinmind2054/evoclaw`. Reply parroted README strings verbatim (`多層記憶 (Hot → PalaceStore → Vector → Shared → Cold)`, `Agent Swarms`, `Skills 2.0`, `DevEngine 7-stage pipeline`) as if they were verified features.

New rule:
- Treat README as hypothesis, not fact.
- Read source (`Glob`/`Grep`/`Read`) before claiming a feature exists.
- Tag every feature claim: `README claims X (not verified)` vs `path/to/file.py:N implements X (verified)`.
- For the EvoClaw repo specifically: agent runs **inside** it (`/workspace/project` for main group), so reading `CLAUDE.md` + `host/main.py` + `container/agent-runner/agent.py` is one tool call away. No excuse.

### #586 — MEMORY.md edits: bounded loop, no internal narration

After processing a Threads URL, the agent spent ~300 lines deliberating where to insert a MEMORY task-log entry (`「等等，這不可能是我剛才完成的...」 → 「或許這是之前會話的記錄?」 → 「讓我重新讀取一下 MEMORY.md...」` ×N) before container OOM-kill.

New rule:
- One `Read` → one `Edit` (append at end of `## 任務記錄`) → one short confirmation → done.
- Forbid user-facing narration of the decision process.
- Cap the loop. If the first append looks right, stop. Do not re-read to "verify".
- Treat existing `[auto] Task: <context...>` XML lines (left over from the #583 bug, fixed in #588) as noise — ignore, don't try to interpret.

## Image rebuild required

**Yes** — `soul.md` ships in `evoclaw-agent:latest`. After merge: `docker build -t evoclaw-agent:latest container/`.

## Test plan

- [x] `git diff` reviewed
- [x] Two new sections placed alongside the existing #584 IPC-enqueue section (same severity, same enforcement style)
- [ ] Post-merge + image rebuild: paste the EvoClaw GitHub URL in chat. Expect: agent calls Read/Grep against `host/` before claiming feature X exists, not a regurgitation of README bullets.
- [ ] Post-merge + image rebuild: ask the agent to "update MEMORY with today's tasks". Expect: one Read + one Edit + a single confirmation line. No multi-paragraph self-questioning narration.

## Relation to other PRs / issues

- #587 (OOM mitigation A+C) addresses *static* memory headroom. This PR addresses one *workload* that exhausts that headroom.
- #588 (MEMORY.md XML-leak fix) cleaned up the bug that confused the agent into the introspection loop in the first place.
- Together, these three reduce #538 OOM frequency without committing to the larger D-H mitigations.

Closes #585.
Closes #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)