### PR TITLE
security(logs): redact Telegram/Discord/Slack tokens from URL log lines (#590)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.27.34] — 2026-05-15
+
+### Security
+- **Stop leaking Telegram bot token (and Discord webhook / Slack hook tokens) into pm2 logs (#590).** `httpx` (used by `python-telegram-bot`) logs every HTTP request URL at `INFO` level, including the token-in-path that Telegram's API mandates (`https://api.telegram.org/bot<TOKEN>/<method>`). pm2 captured 49,172 such lines into `D:\AI_Agent_Dev\evoclaw\logs\pm2-err.log` (33 MB) over a 6-day run — anyone with read access to that file could extract a working token and impersonate the bot. New `SecretUrlRedactor` (`host/log_formatter.py`) is a `logging.Filter` attached to the root logger by `_setup_logging()`; it rewrites the token portion of Telegram, Discord-webhook, and Slack-hook URLs in `record.msg` and `record.args` before any handler emits.  Covers all child loggers via propagation, including third-party (`httpx`, `urllib3`, `discord.gateway`).
+
+### Technical Details
+- **New code**: `host/log_formatter.py` — `SecretUrlRedactor` class + `_redact_url_secrets()` helper + `_SECRET_URL_PATTERNS` tuple covering Telegram / Discord / Slack patterns.
+- **Wired in**: `host/main.py:_setup_logging()` — `root.addFilter(SecretUrlRedactor())` after handler attach.
+- **Tests**: `tests/test_log_redactor.py` — 11 unit tests covering each pattern, plain-line pass-through, tuple-args, dict-args, non-string args.
+- **Image rebuild required**: No (host-side change only — `pm2 restart evoclaw` is sufficient).
+- **Breaking Changes**: None for end-users.  Existing log shippers / Loki dashboards see `***REDACTED***` in place of the secret portion of URLs; the rest of the URL (path, status, timing) is unchanged.
+- **Operator follow-up** (NOT part of this PR):
+  1. The 33 MB of existing `pm2-err.log` still contains the working token. After deploy: rotate the Telegram bot token at BotFather, update `.env`, then `pm2 flush evoclaw` to purge the historic log.
+  2. Same goes for any Discord webhook / Slack hook tokens that previously hit the log.
+
 ## [1.27.33] — 2026-05-15
 
 ### Fixed

--- a/host/log_formatter.py
+++ b/host/log_formatter.py
@@ -1,4 +1,4 @@
-"""Structured JSON log formatter for evoclaw.
+"""Structured JSON log formatter + secret-URL redaction for evoclaw.
 
 When LOG_FORMAT=json, every log record is emitted as a single-line JSON object:
 {
@@ -11,9 +11,15 @@ When LOG_FORMAT=json, every log record is emitted as a single-line JSON object:
   "folder": "telegram_foo",
   "exc": "Traceback ..."            # only present when exception attached
 }
+
+#590: this module also exposes ``SecretUrlRedactor``, a ``logging.Filter`` that
+rewrites known secret-bearing URL patterns inside the record's ``msg`` and
+``args`` so third-party loggers (httpx, urllib3, discord.gateway, ...) cannot
+leak credentials into stdout / pm2 log files.
 """
 import json
 import logging
+import re
 from datetime import datetime, timezone
 
 
@@ -75,3 +81,64 @@ class JsonFormatter(logging.Formatter):
             obj["exc"] = self.formatException(record.exc_info)
 
         return json.dumps(obj, ensure_ascii=False, default=str)
+
+
+# #590: redact secret-bearing URL patterns so third-party loggers (httpx,
+# urllib3, discord.gateway, ...) cannot leak credentials into pm2 / log files.
+#
+# Currently covers:
+#   - Telegram:  https://api.telegram.org/bot<digits>:<base64>/<method>
+#                → https://api.telegram.org/bot***REDACTED***/<method>
+#   - Discord:   https://discord.com/api/webhooks/<id>/<token>
+#                → https://discord.com/api/webhooks/<id>/***REDACTED***
+#   - Slack:     https://hooks.slack.com/services/<workspace>/<channel>/<token>
+#                → https://hooks.slack.com/services/<workspace>/<channel>/***REDACTED***
+#
+# Add new patterns here when a new channel / service is wired in.
+_SECRET_URL_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"(api\.telegram\.org/bot)\d+:[A-Za-z0-9_-]+(/)"),
+        r"\1***REDACTED***\2",
+    ),
+    (
+        re.compile(r"(discord(?:app)?\.com/api/webhooks/\d+/)[A-Za-z0-9_-]+"),
+        r"\1***REDACTED***",
+    ),
+    (
+        re.compile(r"(hooks\.slack\.com/services/[A-Z0-9]+/[A-Z0-9]+/)[A-Za-z0-9_-]+"),
+        r"\1***REDACTED***",
+    ),
+)
+
+
+def _redact_url_secrets(text: str) -> str:
+    """Apply every secret-URL pattern to *text*. No-op if no pattern matches."""
+    for pattern, replacement in _SECRET_URL_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+class SecretUrlRedactor(logging.Filter):
+    """Redact secret-bearing URLs in any log record (msg + args).
+
+    Installed once on the root logger by :func:`host.main._setup_logging` so
+    it runs before every handler emit, covering third-party loggers as well
+    as evoclaw's own.  Mutates the record in place; always returns True so
+    the record itself is never dropped — only its content is sanitised.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = _redact_url_secrets(record.msg)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {
+                    k: (_redact_url_secrets(v) if isinstance(v, str) else v)
+                    for k, v in record.args.items()
+                }
+            else:
+                record.args = tuple(
+                    _redact_url_secrets(a) if isinstance(a, str) else a
+                    for a in record.args
+                )
+        return True

--- a/host/main.py
+++ b/host/main.py
@@ -207,8 +207,13 @@ def _setup_logging() -> None:
     LOG_FORMAT=json  → emit newline-delimited JSON (compatible with Loki/Datadog/CloudWatch)
     LOG_FORMAT=text  → human-readable text (default)
     LOG_LEVEL        → logging level (default: INFO)
+
+    #590: SecretUrlRedactor is attached to the root logger so third-party
+    libraries (httpx, urllib3, discord.gateway) cannot leak Telegram bot
+    tokens / Discord webhook tokens / Slack hook tokens via their default
+    INFO-level URL logging.
     """
-    from host.log_formatter import JsonFormatter
+    from host.log_formatter import JsonFormatter, SecretUrlRedactor
 
     level = getattr(logging, config.LOG_LEVEL, logging.INFO)
     log_format = config.LOG_FORMAT
@@ -228,6 +233,10 @@ def _setup_logging() -> None:
     # Remove any existing handlers to avoid duplicate output
     root.handlers.clear()
     root.addHandler(handler)
+    # Install secret-URL redactor on the root logger (#590).  The filter
+    # mutates msg/args in place so every handler — and every child logger
+    # that propagates to root — sees the redacted text.
+    root.addFilter(SecretUrlRedactor())
 
 
 _setup_logging()

--- a/tests/test_log_redactor.py
+++ b/tests/test_log_redactor.py
@@ -1,0 +1,100 @@
+"""Tests for the secret-URL redactor that protects pm2 logs (#590)."""
+import logging
+
+import pytest
+
+from host.log_formatter import SecretUrlRedactor, _redact_url_secrets
+
+
+@pytest.fixture
+def filt() -> SecretUrlRedactor:
+    return SecretUrlRedactor()
+
+
+def _make_record(msg: str, args: tuple | dict | None = None) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=args,
+        exc_info=None,
+    )
+
+
+class TestRedactUrlSecrets:
+    def test_telegram_url_is_redacted(self):
+        s = "HTTP Request: POST https://api.telegram.org/bot8744114061:AAGzGHcU2KZI7Y0IRJFzJL245WCvW7_8pEo/getMe HTTP/1.1 200 OK"
+        out = _redact_url_secrets(s)
+        assert "AAGzGHcU2KZI7Y0IRJFzJL245WCvW7_8pEo" not in out
+        assert "8744114061" not in out
+        assert "/bot***REDACTED***/getMe" in out
+
+    def test_discord_webhook_is_redacted(self):
+        s = "POST https://discord.com/api/webhooks/123456/abcdefghijkl_MNOPQR-stuvwx"
+        out = _redact_url_secrets(s)
+        assert "abcdefghijkl_MNOPQR-stuvwx" not in out
+        assert "/webhooks/123456/***REDACTED***" in out
+
+    def test_discordapp_webhook_alias_is_redacted(self):
+        s = "POST https://discordapp.com/api/webhooks/123/secrettoken"
+        out = _redact_url_secrets(s)
+        assert "secrettoken" not in out
+        assert "/webhooks/123/***REDACTED***" in out
+
+    def test_slack_hook_is_redacted(self):
+        s = "POST https://hooks.slack.com/services/T0XXX/B0YYY/zZ_aB_secret_token"
+        out = _redact_url_secrets(s)
+        assert "zZ_aB_secret_token" not in out
+        assert "/services/T0XXX/B0YYY/***REDACTED***" in out
+
+    def test_plain_log_line_unchanged(self):
+        s = "evoclaw - INFO - container started for telegram_foo"
+        assert _redact_url_secrets(s) == s
+
+    def test_partial_match_only_redacts_secret_part(self):
+        s = "see api.telegram.org/bot123:abc/sendMessage and api.telegram.org/bot456:def/getMe"
+        out = _redact_url_secrets(s)
+        assert "123:abc" not in out
+        assert "456:def" not in out
+        assert out.count("***REDACTED***") == 2
+
+
+class TestSecretUrlRedactor:
+    def test_filter_returns_true(self, filt: SecretUrlRedactor):
+        rec = _make_record("plain log")
+        assert filt.filter(rec) is True
+
+    def test_msg_is_redacted_in_place(self, filt: SecretUrlRedactor):
+        rec = _make_record("POST https://api.telegram.org/bot1:abc/getMe done")
+        filt.filter(rec)
+        assert "1:abc" not in rec.msg
+        assert "***REDACTED***" in rec.msg
+
+    def test_args_tuple_is_redacted_in_place(self, filt: SecretUrlRedactor):
+        rec = _make_record(
+            "%s and %s",
+            args=(
+                "https://api.telegram.org/bot1:abc/getMe",
+                "https://hooks.slack.com/services/T/B/secret",
+            ),
+        )
+        filt.filter(rec)
+        assert all("***REDACTED***" in a and "abc" not in a and "secret" not in a for a in rec.args)
+
+    def test_non_string_args_pass_through(self, filt: SecretUrlRedactor):
+        rec = _make_record("%s %d %s", args=("ok", 42, None))
+        filt.filter(rec)
+        assert rec.args == ("ok", 42, None)
+
+    def test_dict_args_are_redacted(self, filt: SecretUrlRedactor):
+        # logging.Logger.log("%(url)s", {"url": "..."}) packs args as a
+        # 1-tuple containing the dict; LogRecord.__init__ then unwraps it
+        # to the bare dict.  Reproduce that here.
+        rec = _make_record("%(url)s", args=({"url": "https://api.telegram.org/bot1:abc/getMe"},))
+        # After the constructor unwraps, rec.args is the dict.
+        assert isinstance(rec.args, dict)
+        filt.filter(rec)
+        assert "1:abc" not in rec.args["url"]
+        assert "***REDACTED***" in rec.args["url"]


### PR DESCRIPTION
## Summary

`httpx` (used by `python-telegram-bot`) logs every HTTP request URL at `INFO`. Telegram's API requires the bot token in the URL path (`https://api.telegram.org/bot<TOKEN>/<method>` — no header alternative), so each Telegram call leaked the full working token to stdout → pm2 → `pm2-err.log`. 49,172 hits in a 33 MB log file over a 6-day run. The same shape applies to Discord webhook URLs and Slack hook URLs.

## Fix

`host/log_formatter.py` gets two new pieces:

- `_SECRET_URL_PATTERNS` — tuple of `(re.Pattern, replacement)` covering Telegram, Discord webhook, and Slack hook URL shapes.
- `SecretUrlRedactor` — a `logging.Filter` that walks `record.msg` and `record.args` (tuple OR dict form), applies the patterns, returns `True` so the record is still emitted with sanitised content.

`host/main.py:_setup_logging()` attaches it to the root logger after `addHandler()`, so every child logger (`httpx`, `urllib3`, `discord.gateway`, evoclaw's own) inherits via propagation.

## Tests

`tests/test_log_redactor.py` — **11 unit tests, all passing locally**:

```
TestRedactUrlSecrets::test_telegram_url_is_redacted PASSED
TestRedactUrlSecrets::test_discord_webhook_is_redacted PASSED
TestRedactUrlSecrets::test_discordapp_webhook_alias_is_redacted PASSED
TestRedactUrlSecrets::test_slack_hook_is_redacted PASSED
TestRedactUrlSecrets::test_plain_log_line_unchanged PASSED
TestRedactUrlSecrets::test_partial_match_only_redacts_secret_part PASSED
TestSecretUrlRedactor::test_filter_returns_true PASSED
TestSecretUrlRedactor::test_msg_is_redacted_in_place PASSED
TestSecretUrlRedactor::test_args_tuple_is_redacted_in_place PASSED
TestSecretUrlRedactor::test_non_string_args_pass_through PASSED
TestSecretUrlRedactor::test_dict_args_are_redacted PASSED
============================= 11 passed in 0.06s ==============================
```

## Operator follow-up (NOT part of this PR)

1. **Rotate the existing Telegram bot token.** The 33 MB of `pm2-err.log` still contains the working token. After deploy: rotate at BotFather → update `.env` → `pm2 flush evoclaw` to purge historic logs.
2. Same for any leaked Discord webhook tokens or Slack hook tokens.

## Test plan

- [x] 11 new unit tests pass locally
- [x] `_redact_url_secrets()` manually exercised against the actual token shape currently in `pm2-err.log`
- [ ] Post-merge + `pm2 restart evoclaw`: tail the new log, confirm `httpx` lines show `bot***REDACTED***/` instead of the real token

Closes #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)