### PR TITLE
fix(logs): move SecretUrlRedactor to handler filter — root-logger filter does not catch propagated records (#590 follow-up)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.27.35] — 2026-05-15
+
+### Security
+- **#590 follow-up: move `SecretUrlRedactor` from root-logger filter to handler filter.** Initial wiring at `host/main.py:_setup_logging()` attached the filter to the root *logger* via `root.addFilter(...)`. Live verification after `pm2 restart` showed Telegram bot tokens **still leaking** into `pm2-err.log` after the restart — `httpx` records propagated to root were emitted untouched. Per Python's logging model, logger-attached filters only see records logged through that logger directly; records propagated from child loggers (`httpx`, `urllib3`, `discord.gateway`, ...) bypass parent-logger filters. Fix: attach the filter to the *handler* via `handler.addFilter(...)`. Handler filters apply to every record the handler emits, including propagated. Added two regression tests in `tests/test_log_redactor.py::TestFilterPlacement` — one that pins the correct (handler) placement, one that pins the broken (logger) placement so a future refactor can't silently re-introduce the leak.
+
+### Technical Details
+- **Modified Files**: `host/main.py:_setup_logging()` (one line moved, comment expanded), `tests/test_log_redactor.py` (two new tests, 13 total).
+- **Image rebuild required**: No (host-side change only).
+- **Verification**: standalone `python -c "..."` script (in PR body) confirms child-logger records now redacted via the handler filter.
+- **Breaking Changes**: None.
+
 ## [1.27.34] — 2026-05-15
 
 ### Security

--- a/host/main.py
+++ b/host/main.py
@@ -228,15 +228,20 @@ def _setup_logging() -> None:
             datefmt="%Y-%m-%d %H:%M:%S",
         ))
 
+    # Install secret-URL redactor on the HANDLER (#590 follow-up).  Filters
+    # attached to a Logger only filter records logged through that logger
+    # directly — records propagated from child loggers (httpx, urllib3,
+    # discord.gateway, ...) are NOT filtered by parent-logger filters per
+    # Python's logging model.  Filters on a Handler are applied to every
+    # record the handler emits, including propagated ones — which is the
+    # behaviour we need.
+    handler.addFilter(SecretUrlRedactor())
+
     root = logging.getLogger()
     root.setLevel(level)
     # Remove any existing handlers to avoid duplicate output
     root.handlers.clear()
     root.addHandler(handler)
-    # Install secret-URL redactor on the root logger (#590).  The filter
-    # mutates msg/args in place so every handler — and every child logger
-    # that propagates to root — sees the redacted text.
-    root.addFilter(SecretUrlRedactor())
 
 
 _setup_logging()

--- a/tests/test_log_redactor.py
+++ b/tests/test_log_redactor.py
@@ -98,3 +98,61 @@ class TestSecretUrlRedactor:
         filt.filter(rec)
         assert "1:abc" not in rec.args["url"]
         assert "***REDACTED***" in rec.args["url"]
+
+
+class TestFilterPlacement:
+    """Regression test for #590 follow-up.
+
+    Filters attached to a *logger* only see records logged through that logger
+    directly — records propagated from child loggers are NOT filtered.  Filters
+    attached to a *handler* see every record the handler emits, including
+    propagated ones.  EvoClaw needs the handler placement so it can catch
+    httpx / urllib3 / discord.gateway URL logs that the host code does not
+    own.  This test pins the correct placement.
+    """
+
+    def test_handler_filter_catches_child_logger_records(self):
+        import io
+
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        handler.setFormatter(logging.Formatter("%(name)s - %(message)s"))
+        handler.addFilter(SecretUrlRedactor())  # the CORRECT placement
+
+        root = logging.getLogger("test_filter_placement_root")
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        root.setLevel(logging.INFO)
+        root.addHandler(handler)
+
+        child = root.getChild("httpx")
+        child.info("POST https://api.telegram.org/bot1:abcdef/getMe done")
+        child.info("POST https://discord.com/api/webhooks/9/secrettoken")
+
+        captured = buf.getvalue()
+        assert "1:abcdef" not in captured
+        assert "secrettoken" not in captured
+        assert captured.count("***REDACTED***") == 2
+
+    def test_logger_filter_does_NOT_catch_child_logger_records(self):
+        """Pin the broken behaviour so a future refactor cannot silently move
+        the filter back onto the logger and re-leak tokens."""
+        import io
+
+        buf = io.StringIO()
+        handler = logging.StreamHandler(buf)
+        handler.setFormatter(logging.Formatter("%(name)s - %(message)s"))
+
+        root = logging.getLogger("test_filter_placement_root_broken")
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        root.setLevel(logging.INFO)
+        root.addHandler(handler)
+        root.addFilter(SecretUrlRedactor())  # the WRONG placement
+
+        child = root.getChild("httpx")
+        child.info("POST https://api.telegram.org/bot1:abcdef/getMe done")
+
+        captured = buf.getvalue()
+        # Token leaks — child propagation bypasses parent-logger filters.
+        assert "1:abcdef" in captured


### PR DESCRIPTION
## Summary — follow-up to #592 (#590)

Live verification after `pm2 restart evoclaw` showed the Telegram bot token **still leaking** into `pm2-err.log` despite #592 being merged:

```
2026-05-15 10:42:41: INFO httpx - HTTP Request: POST https://api.telegram.org/bot8744114061:AAGzGHcU2KZI7Y0IRJFzJL245WCvW7_8pEo/getMe "HTTP/1.1 200 OK"
```

Root cause: #592 attached `SecretUrlRedactor` to the root **logger**. Per Python's logging model, logger-attached filters only see records logged through that logger directly. Records propagated from child loggers (`httpx`, `urllib3`, `discord.gateway`, ...) **bypass** parent-logger filters.

Fix: attach the filter to the **handler** instead. Handler filters apply to every record the handler emits, including propagated. One-line move at `host/main.py:_setup_logging()`.

## Standalone verification

```python
import logging, io
from host.log_formatter import SecretUrlRedactor

buf = io.StringIO()
handler = logging.StreamHandler(buf)
handler.setFormatter(logging.Formatter("%(name)s - %(message)s"))
handler.addFilter(SecretUrlRedactor())  # the fix

root = logging.getLogger()
root.setLevel(logging.INFO)
root.handlers.clear()
root.addHandler(handler)

child = logging.getLogger("httpx")
child.info("POST https://api.telegram.org/bot1:abcdef/getMe done")

# Output: 'httpx - POST https://api.telegram.org/bot***REDACTED***/getMe done'
assert "1:abcdef" not in buf.getvalue()
```

## Regression tests

`tests/test_log_redactor.py::TestFilterPlacement` adds two tests:

1. `test_handler_filter_catches_child_logger_records` — pins the CORRECT placement.
2. `test_logger_filter_does_NOT_catch_child_logger_records` — pins the BROKEN placement so a future refactor cannot silently re-introduce the leak.

```
13 passed in 0.04s
```

## Test plan

- [x] 13 unit tests pass locally (was 11, added 2 placement tests)
- [x] Standalone repro confirms child-logger records redacted via handler filter
- [ ] Post-merge + `pm2 restart evoclaw`: tail new log, confirm `httpx` lines show `bot***REDACTED***/`

Refs #590 (the original fix landed in #592 but did not actually take effect on propagated records — this PR closes the loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)