### PR TITLE
fix(logs): redact httpx.URL objects in log args, not just str (#590 follow-up #2)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.27.36] — 2026-05-15
+
+### Security
+- **#590 follow-up #2: redact `httpx.URL` objects in log args, not just `str`.** After landing #593 (handler-attached filter) live verification on the running pm2 process still showed Telegram bot tokens in `pm2-err.log`.  Debug instrumentation revealed `httpx` passes the URL as a `httpx.URL(...)` *object*, not a plain `str` — so the previous `isinstance(arg, str)` guard skipped it and `%s` rendered the unredacted URL via `__str__`.  New `_maybe_redact_any()` helper: stringifies non-str args, runs the redactor, and only swaps in the redacted string when the redactor matched something (so type-sensitive format specifiers like `%d` for ints keep working).  Live `pm2 restart evoclaw` verified: 30/30 recent `httpx` lines now show `bot***REDACTED***/`.
+
+### Technical Details
+- **Modified Files**: `host/log_formatter.py` (new `_maybe_redact_any()` helper, filter now uses it for both tuple and dict args).
+- **Tests**: `tests/test_log_redactor.py` — 2 new tests under `TestSecretUrlRedactor` (`test_url_object_arg_is_redacted`, `test_non_url_object_arg_keeps_type`).  15 tests total, all passing.
+- **Image rebuild required**: No.
+- **Live verification**: `grep "httpx" pm2-err.log | tail -30 → 0 leaks, 30 redacted`.
+- **Breaking Changes**: None.
+
 ## [1.27.35] — 2026-05-15
 
 ### Security

--- a/host/log_formatter.py
+++ b/host/log_formatter.py
@@ -133,12 +133,34 @@ class SecretUrlRedactor(logging.Filter):
         if record.args:
             if isinstance(record.args, dict):
                 record.args = {
-                    k: (_redact_url_secrets(v) if isinstance(v, str) else v)
-                    for k, v in record.args.items()
+                    k: _maybe_redact_any(v) for k, v in record.args.items()
                 }
             else:
-                record.args = tuple(
-                    _redact_url_secrets(a) if isinstance(a, str) else a
-                    for a in record.args
-                )
+                record.args = tuple(_maybe_redact_any(a) for a in record.args)
         return True
+
+
+def _maybe_redact_any(arg):
+    """Redact an arbitrary log-record argument that may not be a plain str.
+
+    #590 follow-up #2: httpx logs URLs as ``httpx.URL(...)`` objects, not as
+    plain strings.  The old ``isinstance(arg, str)`` guard skipped them, so
+    the formatter's ``%s`` placeholder rendered the unredacted URL via the
+    object's ``__str__`` method.  This helper:
+
+    - For str arguments: run the redactor directly.
+    - For non-str arguments: stringify with ``str(arg)``, run the redactor,
+      and only swap in the redacted string when the redactor actually
+      matched something.  Otherwise return the original object unchanged so
+      type-sensitive format specifiers (e.g. ``%d`` for an int) still work.
+    """
+    if isinstance(arg, str):
+        return _redact_url_secrets(arg)
+    try:
+        as_str = str(arg)
+    except Exception:
+        return arg
+    redacted = _redact_url_secrets(as_str)
+    if redacted != as_str:
+        return redacted
+    return arg

--- a/tests/test_log_redactor.py
+++ b/tests/test_log_redactor.py
@@ -88,6 +88,33 @@ class TestSecretUrlRedactor:
         filt.filter(rec)
         assert rec.args == ("ok", 42, None)
 
+    def test_url_object_arg_is_redacted(self, filt: SecretUrlRedactor):
+        """#590 follow-up #2: httpx passes URLs as ``httpx.URL(...)`` objects,
+        not plain str.  Confirm a string-like wrapper whose ``__str__``
+        contains a secret URL gets redacted."""
+        class _URL:
+            def __init__(self, s: str):
+                self._s = s
+            def __str__(self) -> str:
+                return self._s
+
+        url = _URL("https://api.telegram.org/bot1:abcdef/getMe")
+        rec = _make_record("%s %s", args=("POST", url))
+        filt.filter(rec)
+        # args[1] should now be a str with the redacted URL, not the original
+        # _URL object (which would re-stringify to the secret form).
+        assert isinstance(rec.args[1], str)
+        assert "1:abcdef" not in rec.args[1]
+        assert "***REDACTED***" in rec.args[1]
+
+    def test_non_url_object_arg_keeps_type(self, filt: SecretUrlRedactor):
+        """Type-sensitive format specifiers (e.g. %d for int) must keep
+        working: only swap arg types when the redactor actually matched."""
+        rec = _make_record("%d", args=(200,))
+        filt.filter(rec)
+        assert rec.args == (200,)
+        assert isinstance(rec.args[0], int)
+
     def test_dict_args_are_redacted(self, filt: SecretUrlRedactor):
         # logging.Logger.log("%(url)s", {"url": "..."}) packs args as a
         # 1-tuple containing the dict; LogRecord.__init__ then unwraps it


### PR DESCRIPTION
## Summary — second follow-up to #590

After #593 landed (handler-attached filter), live `pm2-err.log` was STILL leaking Telegram bot tokens. Live debug instrumentation revealed the cause:

```
DBG590: httpx record at filter | msg='HTTP Request: %s %s "%s %d %s"' args=('POST', URL('https://api.telegram.org/bot8744114061:AAGzGHcU.../getMe'), 'HTTP/1.1', 200, 'OK')
```

`httpx` passes the URL as a **`httpx.URL(...)` object**, not a plain `str`. The previous `isinstance(arg, str)` guard skipped it. The `%s` formatter then rendered the unredacted URL via `__str__`.

## Fix

New `_maybe_redact_any()` helper:

```python
def _maybe_redact_any(arg):
    if isinstance(arg, str):
        return _redact_url_secrets(arg)
    try:
        as_str = str(arg)
    except Exception:
        return arg
    redacted = _redact_url_secrets(as_str)
    if redacted != as_str:
        return redacted
    return arg
```

For non-str args: stringify, run redactor, swap to str ONLY if redactor matched. Otherwise return original object so type-sensitive specifiers (`%d`, etc.) still work.

## Live verification

After `pm2 restart evoclaw`:

```
$ grep "httpx" pm2-err.log | tail -30 | awk '/bot[0-9]+:.+\//{leak++} /REDACTED/{red++} END{print "leak:", leak+0, "red:", red+0}'
leak: 0 red: 30
```

30/30 recent `httpx` lines now redacted.

## Tests

2 new under `TestSecretUrlRedactor`:

- `test_url_object_arg_is_redacted` — string-like wrapper whose `__str__` contains a secret URL gets redacted.
- `test_non_url_object_arg_keeps_type` — int args (e.g. `200` for `%d`) stay int.

15 unit tests total, all passing.

## Test plan

- [x] 15 unit tests pass locally
- [x] Live `pm2-err.log` shows 30/30 `httpx` lines redacted after `pm2 restart`
- [x] Other args (status code `200`) keep their int type — no `TypeError` from `%d`

Refs #590. (#592 = pattern + Filter, #593 = move to handler, this = handle URL-object args.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)