### PR TITLE
docs: import strategy/fluidity plans + feasibility audit (#595)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.27.37] — 2026-05-15
+
+### Added
+- **`docs/FLUIDITY_AND_DAYTONA_PLAN.md`** — imported from sibling repo; analyses why EvoClaw's per-turn `docker run` model feels slow vs `nanoclaw` / `hermes agent` and proposes a 4-phase migration toward a long-lived stateful agent runtime (optionally on Daytona).  **Added §19–22 "可行性審視"**: every code-citation claim verified against current `host/` and `container/agent-runner/`; phase estimates re-baselined (original 12-21 weeks → realistic 20-31 weeks, 30-50% optimistic); flagged 5 risks the original missed (Daytona OSS still on Docker Compose, untested on Windows host, no python-tests regression net, ignored today's #583–#594 fixes, no #538 OOM baseline); added explicit go/no-go decision nodes between phases.
+- **`docs/PRODUCT_STRATEGY.md`** — imported from sibling repo; positions EvoClaw as a *Persistent Multi-Agent Operations Platform* rather than competing with coding agents.  **Added §14–17 "可行性審視"**: maps each strategy claim (`Persistent / Multi-Agent / Governable / Group-native / 5-layer Memory / Skills 2.0 / DevEngine`) to real `host/` modules and notes which README claims exceed code maturity (links to #585); estimates 50-150h per Solution Pack; flags that the 6-month timeline to revenue is optimistic; recommends a 6-month plan that ships *one* Pack (Community Manager) rather than three.
+
+### Why this matters
+- Both docs existed only in a sibling repo where they could not be discovered by EvoClaw contributors.
+- The audited versions ground every claim in current code rather than aspirational README rhetoric (the same hazard logged in #585).
+- Future technical and product decisions now have a versioned, code-grounded reference point.
+
+### Technical Details
+- **New Files**: `docs/FLUIDITY_AND_DAYTONA_PLAN.md`, `docs/PRODUCT_STRATEGY.md`.
+- **Image rebuild required**: No (docs only).
+- **Breaking Changes**: None.
+- Closes #595.
+
 ## [1.27.36] — 2026-05-15
 
 ### Security

--- a/docs/FLUIDITY_AND_DAYTONA_PLAN.md
+++ b/docs/FLUIDITY_AND_DAYTONA_PLAN.md
@@ -1,0 +1,869 @@
+# EvoClaw 流暢度分析與 Daytona 遷移改善方案
+
+更新日期: 2026-05-15
+最近審視: 2026-05-15（加入可行性審視段，章節 19–22）
+
+## 1. 目的
+
+這份文件整合兩個問題：
+
+1. 為什麼這個專案跑起來的流暢度不如 `nanoclaw` 或 `hermes agent`
+2. 是否應該把目前的 Docker 執行層改成 Daytona，以及怎麼改
+
+本文件結論建立在目前 repo 的實際結構上，不假設我已經掌握 `nanoclaw` 或 `hermes agent` 的完整內部實作。對它們的比較，僅作為「互動體感方向」的參照，而不是實作層面的逐行對照。
+
+## 2. 高層結論
+
+EvoClaw 現在的核心定位，比較接近：
+
+- 高安全性
+- 多功能
+- 可觀測
+- 可演化
+- 帶排程、記憶、dashboard、IPC、subagent、RBAC 的 orchestration framework
+
+而不是：
+
+- 低延遲
+- 長駐狀態
+- 即時串流
+- 互動優先
+- session-first 的 agent runtime
+
+所以它「不好用」的主因，不是單點 bug，而是整體執行模型天然比較重。
+
+一句話總結：
+
+**EvoClaw 目前像一個安全而完整的 agent orchestration system，不像一個輕快的長駐式 agent runtime。**
+
+如果目標是接近 `nanoclaw` / `hermes agent` 那種互動感，真正要改的是主執行模型，而不是只補幾個穩定性修正。
+
+## 3. 現況架構摘要
+
+從專案文件與程式碼看，當前主路徑大致如下：
+
+1. Channel 收到訊息
+2. `host/main.py` 做路由、限流、排隊、記錄
+3. `host/group_queue.py` 以群組為單位排隊
+4. `host/container_runner.py` 用 `docker run` 啟動 agent container
+5. Host 組裝 prompt / history / memory / scheduled tasks / secrets，經 stdin 丟給 container
+6. Container 內 `container/agent-runner/agent.py` 選 backend、建立 system prompt、跑多輪 tool loop
+7. 結果再經 stdout marker 回 Host
+8. Host 再做 DB、記憶更新、訊息回傳、IPC 收尾
+
+相關程式位置：
+
+- `host/main.py`
+- `host/container_runner.py`
+- `host/group_queue.py`
+- `host/ipc_watcher.py`
+- `container/agent-runner/agent.py`
+- `docs/ARCHITECTURE.md`
+- `docs/STABILITY_ANALYSIS.md`
+
+## 4. 為什麼體感不流暢
+
+### 4.1 每回合都是冷路徑，不是長駐熱路徑
+
+最重要的原因是 `host/container_runner.py` 每次互動都會走 `docker run`。
+
+這表示每一輪都要經過：
+
+- host 準備資料
+- 啟動 Docker CLI
+- 建 container
+- mount volume
+- 傳 stdin JSON
+- container 內初始化 agent
+- 載入對應 LLM SDK
+- 執行多輪 reasoning / tool loop
+- 經 stdout marker 回傳
+- host 再 parse / cleanup / docker rm
+
+這條鏈路即使沒有 bug，也會比長駐 process 慢很多。
+
+對比手感比較好的 agent，一般會有以下特徵：
+
+- 長駐 session
+- process 不重啟
+- SDK / tools / prompt cache 保留在記憶體
+- 後端直接串流結果，不需經過 marker 協定
+
+### 4.2 IPC 還帶著 file polling 的設計包袱
+
+架構文件直接寫了 v1.x 是 file-based IPC + polling，而 v2.x 才打算走 WebSocket。
+
+實際上 `host/ipc_watcher.py` 在 Linux 可以走 inotify，但其他平台會 fallback 到 polling。
+
+而你目前環境是 Windows，這特別不利於流暢度。
+
+影響包括：
+
+- 任務完成到 host 感知之間有 polling 延遲
+- JSON 檔寫入、讀取、搬移、錯誤處理本身就很重
+- race condition / partial write / watcher backpressure 會帶來額外保守機制
+
+### 4.3 訊息被 GroupQueue / scheduler / background task 壓住
+
+`host/group_queue.py` 的設計目標是穩定性，不是互動體感。
+
+目前特性是：
+
+- 每個 group 同時只跑一個 container
+- 全域還有 `MAX_CONCURRENT_CONTAINERS`
+- tasks 優先於 messages
+- failure 有 retry / backoff / circuit breaker
+
+這些都合理，但聊天產品會因此變鈍。
+
+具體問題：
+
+- scheduler 可能跟互動訊息搶 slot
+- dev task / subagent / background memory 工作也會佔資源
+- 同一 group 的任務與互動無法真正並行
+
+### 4.4 每回合 prompt 太胖
+
+Host 端會組裝大量內容進 input JSON：
+
+- `conversationHistory`
+- `scheduledTasks`
+- `hotMemory`
+- `evolutionHints`
+- secrets
+
+另外 container 端還會再讀：
+
+- `MEMORY.md`
+- `global/CLAUDE.md`
+- `group/CLAUDE.md`
+- system prompt 強化規則
+- Qwen 特例規則
+
+這種設計讓 agent 比較不容易失憶，但代價是：
+
+- token 大
+- 首 token 慢
+- tool 決策變繞
+- 每輪都在重建大 prompt
+
+### 4.5 工具循環是多輪 reasoning-heavy 設計
+
+目前 agent 不是「一次生成」，而是 multi-turn tool loop。
+
+且 `MAX_ITER` 是根據 prompt 長度與關鍵字做 heuristic，Level B 預設可到 20 輪。
+
+這很適合做複雜 coding / debugging / orchestration，但不適合每個互動都追求快感。
+
+### 4.6 預設 backend 選擇偏成本/兼容，不偏最佳互動體感
+
+目前 backend priority 是：
+
+- NIM / OpenAI-compatible
+- Claude
+- Gemini
+
+如果沒有前兩者，就落到 Gemini default。這比較像成本/可用性導向的策略，不是「互動俐落度優先」。
+
+### 4.7 系統把 correctness 放在 UX 前面
+
+從 `STABILITY_ANALYSIS.md` 看得很明顯，近幾個 phase 大量工作都在修：
+
+- race condition
+- pipe / marker 問題
+- backpressure
+- watchdog
+- token revocation
+- DB integrity
+- UTF-8 / OOM / timeout / zombie process
+
+這表示系統的大量設計負擔都在「避免錯、避免掛、避免誤導」。
+這是好事，但也代表它不是從頭以「極致順手」為第一優先。
+
+## 5. 與 nanoclaw / hermes 類產品的體感差異
+
+這裡只做合理推斷，不聲稱我已審完它們內部實作。
+
+流暢度較好的 agent，常見特徵通常是：
+
+- 長駐 runtime
+- 直接 SDK call
+- 輕量 prompt
+- 較少 orchestration hop
+- token / progress streaming
+- 互動任務與背景任務明確分流
+
+EvoClaw 目前則是：
+
+- 每輪 container job
+- host 與 runtime 分離
+- file IPC 歷史包袱
+- prompt 重
+- queue / scheduler / memory / watchdog 都在同條主路徑附近
+
+所以體感慢是預期結果，不是意外。
+
+## 6. 根因分類
+
+### 6.1 執行模型問題
+
+- 每回合 `docker run`
+- process 非長駐
+- SDK 無法持續熱身
+- 工具與對話狀態缺少 session retention
+
+### 6.2 通訊模型問題
+
+- stdin/stdout marker 協定
+- file IPC / polling
+- 非 event-stream 原生
+
+### 6.3 狀態管理問題
+
+- 過多狀態透過 prompt 重建
+- 長期記憶與當前工作狀態沒有明確分層
+- conversation history 以「重放文字」為主，不是「結構化對話狀態」
+
+### 6.4 調度策略問題
+
+- 任務優先於訊息
+- 背景任務與互動訊息共用資源池
+- group-level serialization 過於保守
+
+### 6.5 產品層 UX 問題
+
+- 真正的 token streaming 不完整
+- 工具進度不夠可見
+- 缺少 fast / deep 模式
+- 缺少前台互動與後台任務分層
+
+## 7. 如果不改底層，只能做到什麼程度
+
+如果保留「每輪 Docker container + host orchestration + file IPC 主架構」，可以做的優化主要是：
+
+- queue 優先級調整
+- prompt 瘦身
+- history / memory summarization
+- fast / balanced / deep 模式
+- 減少 tool result 回注
+- 更好的 streaming UX
+
+這些都會有幫助，但上限有限。
+
+因為最大成本仍然是：
+
+- 冷啟
+- IPC
+- 重 prompt
+- 多 hop
+
+## 8. Daytona 是否適合作為替代執行層
+
+結論：
+
+**適合，但不能當成 Docker CLI 的 drop-in replacement。**
+
+### 8.1 Daytona 的定位
+
+根據官方資料，Daytona 是：
+
+- secure and elastic infrastructure for running AI-generated code
+- 以 sandbox 為核心
+- 提供 filesystem / process / git / code interpreter / desktop automation
+- 支援程式化建立、停止、重啟、封存、刪除 sandbox
+
+官方資料：
+
+- GitHub: https://github.com/daytonaio/daytona
+- Docs: https://www.daytona.io/docs/
+- Sandbox management: https://www.daytona.io/docs/sandbox-management/
+
+### 8.2 Daytona 為什麼符合這個案子想要的方向
+
+它能提供你目前最缺的幾件事：
+
+1. **長駐 sandbox**
+   可用 create / stop / start / archive 管理，不必每輪重建執行環境。
+
+2. **直接 process / fs / git API**
+   很多現在靠 Docker mount + stdin/stdout + file IPC 做的事，可以走 SDK。
+
+3. **更像 stateful workspace，而不是 batch job**
+   這跟「好用 agent」的方向一致。
+
+### 8.3 Daytona 不是「完全脫離 Docker」
+
+這點要講清楚。
+
+官方文件顯示：
+
+- Daytona built on OCI / Docker compatibility
+- 開源自架本身是 Docker Compose
+- snapshots 也支援 Docker / OCI image
+
+所以你如果問的是：
+
+**「我能不能不要在 EvoClaw 裡直接維護 Docker CLI batch lifecycle？」**
+
+答案是：可以，用 Daytona 很合理。
+
+但如果問的是：
+
+**「整個底層完全不再和 Docker 生態有關？」**
+
+答案是：不是 Daytona 的主要用法。
+
+## 9. Daytona 對這個專案的實際收益
+
+### 9.1 最有價值的收益
+
+1. 移除每回合 `docker run` 冷啟
+2. 讓每個 group/session 有長駐 workspace
+3. 讓 agent 執行環境具備持久檔案系統
+4. 讓 process / fs / git 可以 API 化
+5. 讓 IPC 從檔案輪詢逐步轉成 event / SDK call
+
+### 9.2 哪些收益不是自動得到的
+
+即便換 Daytona，下列問題仍要自己做：
+
+- GroupQueue 優先級
+- prompt 瘦身
+- history / memory state 化
+- front/background 任務分流
+- token / progress streaming
+
+也就是說：
+
+**Daytona 解的是執行層與 session 模型，不會自動修正產品層設計。**
+
+## 10. 不建議怎麼換
+
+### 10.1 不建議直接把 Docker 全刪掉
+
+因為目前大量穩定性設計都綁在 `container_runner.py` 路徑。
+一口氣全改，風險太高。
+
+### 10.2 不建議把 Docker CLI 字串直接改成 Daytona API
+
+這樣會保留原有 batch 思維，收益很小。
+
+正確做法是：
+
+- 抽象 runtime interface
+- 保留 DockerRuntime
+- 新增 DaytonaRuntime
+- 逐步切換主對話路徑
+
+### 10.3 不建議一開始就遷 scheduler / subagent / memory bus
+
+先把主互動路徑做好，再處理背景任務。
+
+## 11. 建議的完整改善計畫
+
+以下分成 4 個 phase。
+
+### 11A. Phase 0: 先量化，不要先猜
+
+時間：3-5 天
+
+先加監測，否則後面所有優化都是憑感覺。
+
+#### 指標
+
+- TTFT: 使用者送出到第一個 token / 第一個進度事件
+- TTR: 使用者送出到完整答案
+- Cold start: runtime 啟動到 agent 開始處理
+- Queue wait time: 進 queue 到真正開始執行
+- Prompt size: system/history/memory chars 或 tokens
+- Tool turns per answer
+- Sandbox/container reuse rate
+
+#### 目標
+
+- TTFT < 1.5s
+- 一般問答 TTR < 4s
+- 複雜任務 first progress < 2s
+- P95 queue wait < 300ms
+- prompt 平均大小下降 40%
+
+### 11B. Phase 1: 不改底層的快速止血
+
+時間：1-2 週
+
+#### 1. 調整 GroupQueue 優先級
+
+把互動訊息設為最高優先。
+
+建議改成：
+
+- interactive user message
+- tool continuation
+- subagent continuation
+- scheduled task / dev task
+
+並保留至少 1 個全域 slot 給互動訊息，不讓 scheduler 吃光。
+
+#### 2. prompt 瘦身
+
+直接調整 policy：
+
+- `MEMORY.md` 注入從 4000 chars 降到 1000-1500 chars
+- `CLAUDE.md` 不全文注入，改為編譯後摘要 capsule
+- conversation history 改為 token budget 控制
+- 最近對話只保留 6-10 turns
+- 舊對話先 summary，再注入
+
+#### 3. 新增 `fast / balanced / deep` 模式
+
+建議：
+
+- `fast`: `MAX_ITER=4`，禁用 subagent，history 最小化
+- `balanced`: 現行預設
+- `deep`: 開完整 reasoning / tool loop
+
+#### 4. 工具結果統一 summary 回注
+
+原則：
+
+- raw output 不直接塞回主模型 history
+- 只回傳 summary: changed / found / next
+- 大輸出只保留 debug head/tail
+
+#### 5. Windows 環境止血
+
+如果短期仍要在 Windows 跑：
+
+- 建議 host 改跑在 Linux / WSL2
+- 或先把 `IPC_POLL_INTERVAL` 調低到 0.2-0.3s 過渡
+
+### 11C. Phase 2: 執行層重構
+
+時間：3-6 週
+
+這是最關鍵的一層。
+
+#### 1. 抽象 runtime interface
+
+先從 `host/container_runner.py` 抽出介面：
+
+```python
+class AgentRuntime(Protocol):
+    async def create_session(...)
+    async def run_turn(...)
+    async def stop_session(...)
+    async def delete_session(...)
+    async def get_stats(...)
+```
+
+#### 2. 保留 `DockerRuntime`
+
+先把現在的 `container_runner.py` 包成 `DockerRuntime`，功能不變。
+
+#### 3. 新增 `DaytonaRuntime`
+
+用 Daytona sandbox 取代 `docker run` batch model。
+
+基本設計：
+
+- 一個 group 對應一個 sandbox
+- sandbox workdir 對應 group workspace
+- agent runner 以長駐 process 或可重複呼叫 process command 執行
+- 檔案同步、process 執行、git 操作都改走 Daytona SDK
+
+#### 4. 主對話路徑先切 Daytona
+
+先只切最重要的：
+
+- interactive user messages
+
+保留 background task 先走 DockerRuntime，降低風險。
+
+### 11D. Phase 3: 拔掉 file IPC，改 event / SDK 模型
+
+時間：3-5 週
+
+#### 1. 拔掉主路徑對 `ipc_watcher.py` 的依賴
+
+把以下互動改為 SDK / runtime 內事件：
+
+- task payload
+- tool progress
+- result delivery
+- memory update
+- subagent return
+
+#### 2. file IPC 只留 fallback
+
+保留檔案式 IPC 作為：
+
+- disaster fallback
+- offline 模式
+- legacy compatibility
+
+但不再作為主路徑。
+
+#### 3. 讓 Host 能直接拿 progress stream
+
+理想狀態：
+
+- model started
+- tool started
+- tool finished
+- summary ready
+- final answer
+
+都變成 event，不再等整包完成。
+
+### 11E. Phase 4: 真正做成 stateful agent runtime
+
+時間：4-8 週
+
+#### 1. session 長駐
+
+不要每回合重跑完整 agent 初始化。
+
+改成：
+
+- sandbox 長駐
+- agent process 長駐
+- session state 留在 runtime memory
+
+#### 2. prompt-first 改成 state-first
+
+目前很多資訊靠 prompt 重建。
+未來應改成：
+
+- identity state
+- current task state
+- pending actions
+- memory summary
+- unresolved questions
+
+這些由 runtime state 維護，而不是全文重播。
+
+#### 3. 將 MEMORY / CLAUDE / soul 轉成 capsule
+
+建立一個 build step：
+
+- source markdown
+- compile to policy capsule
+- inject compact form only
+
+#### 4. 前台聊天與後台任務完全分離
+
+建立不同 worker pool：
+
+- interactive pool
+- background task pool
+- subagent pool
+- summarization pool
+
+避免聊天被背景任務卡死。
+
+## 12. Daytona 遷移的實際技術設計
+
+### 12A. 遷移目標
+
+只替換執行層，不一開始就推翻整個 Host。
+
+保留：
+
+- `host/main.py`
+- `host/group_queue.py`
+- `host/task_scheduler.py`
+- `host/db.py`
+- channels
+
+替換：
+
+- `host/container_runner.py` 的底層執行模型
+
+### 12B. 建議的 sandbox 模型
+
+#### 單位
+
+- 1 個 group = 1 個 Daytona sandbox
+
+#### 狀態
+
+- active: 近期有互動，長駐
+- stopped: 閒置但保留檔案系統
+- archived: 久未使用，降成本
+
+#### 對應資料
+
+- `sandbox_id`
+- `group_folder`
+- `last_active_at`
+- `runtime_state`
+- `sandbox_backend = docker | daytona`
+
+可新增資料表或放進現有 state store。
+
+### 12C. 最小可行 DaytonaRuntime
+
+第一版只做 5 件事：
+
+1. create/find sandbox
+2. sync workspace
+3. execute agent turn
+4. collect stdout/stderr/result
+5. stop/delete sandbox
+
+第一版先容忍：
+
+- 還沒有真正 token stream
+- 還沒有 process 常駐
+- 還沒有完全去除 legacy prompt 組裝
+
+目標是先證明：
+
+**同一 sandbox 反覆執行，比每輪 `docker run` 快。**
+
+### 12D. 第二版 DaytonaRuntime
+
+完成後要升級成：
+
+- sandbox reuse
+- process reuse
+- stateful session
+- event streaming
+- direct file/process API
+
+## 13. 具體工程拆解
+
+### 13A. 第 1 週
+
+- 加 latency / prompt / queue metrics
+- 實作 fast/balanced/deep 模式
+- 調整 GroupQueue 優先級
+- 限縮 memory/history 注入
+
+交付：
+
+- metrics dashboard
+- P50/P95 latency baseline
+
+### 13B. 第 2 週
+
+- 抽 `AgentRuntime` 介面
+- 把現有 Docker 路徑包成 `DockerRuntime`
+- 寫 runtime adapter tests
+
+交付：
+
+- Host 對 Docker 路徑不再直接依賴實作細節
+
+### 13C. 第 3-4 週
+
+- 新增 `DaytonaRuntime` MVP
+- 做 sandbox create/find/delete
+- 跑通單輪互動訊息
+
+交付：
+
+- 單一 group 可用 Daytona 路徑回應
+
+### 13D. 第 5-6 週
+
+- 做 sandbox reuse
+- 補 runtime state persistence
+- 將主對話路徑切到 Daytona
+
+交付：
+
+- 主互動路徑不再每回合 `docker run`
+
+### 13E. 第 7-8 週
+
+- 移除主路徑 file IPC
+- 增加 progress events
+- subagent 路徑改 API 化
+
+交付：
+
+- `ipc_watcher.py` 不再處於主互動關鍵路徑
+
+### 13F. 第 9-12 週
+
+- process 常駐
+- stateful session
+- prompt capsule 化
+- background pool 與 interactive pool 分離
+
+交付：
+
+- 體感大幅改善
+
+## 14. 預期效益排序
+
+若只看體感收益，排序如下：
+
+1. **每回合 Docker batch -> 長駐 sandbox session**
+2. **file IPC/polling -> event / API**
+3. **prompt 瘦身**
+4. **interactive 優先級**
+5. **streaming UX**
+6. **background 與 foreground 分流**
+
+## 15. 風險與代價
+
+### 15.1 引入 Daytona 會新增平台依賴
+
+你要接受：
+
+- Daytona SDK / API
+- sandbox lifecycle 管理
+- 新的部署與觀測面
+
+### 15.2 不是一天完成
+
+這不是「改幾行 Docker 指令」。
+它本質上是 runtime model migration。
+
+### 15.3 要有 fallback
+
+建議長期保留：
+
+- `DockerRuntime`
+- feature flag
+- per-group backend selection
+
+避免 Daytona 出現平台問題時整站回不來。
+
+## 16. 最務實的決策建議
+
+### 如果你只想短期變順
+
+先做：
+
+- Phase 0
+- Phase 1
+
+不要立刻碰 Daytona。
+
+### 如果你想中長期把 EvoClaw 變成真正好用的 agent
+
+要做：
+
+- runtime adapter
+- DaytonaRuntime
+- session-based sandbox reuse
+- event 化通訊
+
+### 如果你問「值不值得改 Daytona」
+
+我的結論是：
+
+**值得，但前提是你把它視為『執行模型升級』，不是『Docker 指令替換』。**
+
+## 17. 最終結論
+
+EvoClaw 目前流暢度不如 `nanoclaw` / `hermes agent`，核心不是模型差，而是：
+
+- 執行模型太重
+- 主路徑太長
+- IPC 太舊
+- prompt 太胖
+- queue 與 background 任務壓住互動體感
+
+若要真正變好用，關鍵路線是：
+
+1. 先做觀測與 prompt/queue 快修
+2. 抽 runtime interface
+3. 把主執行層從 Docker batch 模式升級為 Daytona sandbox session
+4. 把檔案 IPC 改成 event / API
+5. 最終把系統做成長駐 stateful agent runtime
+
+## 18. 外部參考
+
+以下是本分析用到的 Daytona 官方資料：
+
+- Daytona GitHub: https://github.com/daytonaio/daytona
+- Daytona Docs: https://www.daytona.io/docs/
+- Sandbox Management: https://www.daytona.io/docs/sandbox-management/
+- Python Sandbox SDK: https://www.daytona.io/docs/en/python-sdk/sync/sandbox/
+- Go SDK: https://www.daytona.io/docs/en/go-sdk/daytona/
+- OSS Deployment: https://www.daytona.io/docs/ja/oss-deployment/
+- Snapshots: https://www.daytona.io/docs/en/snapshots/
+
+---
+
+## 19. 可行性審視（2026-05-15 加入）
+
+以下章節由 Claude Code session 對照當前 repo `keepinmind2054/evoclaw` HEAD `e999603` 之後的 main 進行驗證，列出每個 phase 的事實確認、實際估時、與原計畫的落差。
+
+### 19.1 事實主張對照
+
+| 文件主張 | 對照位置 | 驗證結果 |
+|---|---|---|
+| 每輪 `docker run` 冷啟 | `host/container_runner.py:623` 起的 `_run_docker` | ✓ 屬實 |
+| File IPC + polling，Windows fallback | `host/ipc_watcher.py:162` `_IPC_MAX_FILES_PER_CYCLE`，Linux inotify 條件分支 | ✓ 屬實 |
+| GroupQueue 序列化 + tasks 優先 | `host/group_queue.py`；`MAX_CONCURRENT_CONTAINERS` 與 task-vs-message 排序 | ✓ 屬實 |
+| Prompt 胖 — stdin JSON 帶 history/memory/hints/secrets | `host/container_runner.py:582` 起的 input 組裝 | ✓ 屬實 |
+| Multi-turn loop MAX_ITER=20 (Level B) | `container/agent-runner/agent.py:457` heuristic | ✓ 屬實 |
+| Backend priority NIM/OpenAI > Claude > Gemini | `container/agent-runner/agent.py:220, 620` | ✓ 屬實 |
+| Daytona 自架 = Docker Compose | 官方 `oss-deployment` 文件 | ✓ 屬實 — 換層抽象，未脫離 Docker 生態 |
+
+文件對 code 的描述全部屬實，無幻覺。
+
+### 19.2 Phase 可行性與時程實算
+
+| Phase | 文件估 | 實算估 | 偏差 | 風險 | 主要不確定性 |
+|---|---|---|---|---|---|
+| 0 — Metrics | 3-5 天 | **3-5 天** | 持平 | 低 | dashboard 已存在，加 timing 注入即可 |
+| 1 — Queue priority + prompt slim + fast/balanced/deep | 1-2 週 | **2-3 週** | +50% | 低 | code 局部改；fast 模式需要新 flag 在 stdin payload 與 agent.py 兩端 |
+| 2 — AgentRuntime interface + Daytona MVP | 3-6 週 | **4-8 週** | +33% | **高** | (a) Daytona OSS 自架 = Docker Compose stack 新元件；(b) workspace 同步機制要寫；(c) `container_runner.py` 安全 invariant 多（path traversal guard, env shadow, oom_score_adj, pids limit, tmpfs）需逐項移植到 Daytona |
+| 3 — Kill file IPC | 3-5 週 | **6-8 週** | +60% | **高** | IPC schema 已有 backpressure / retry / security guards / per-cycle cap。事件化要 bridge legacy。Scheduler / subagent 同條路徑會被牽動 |
+| 4 — Long-lived runtime + capsule prompt | 4-8 週 | **8-12 週** | +50% | **最高** | (a) agent.py 主迴圈大改；(b) session state 持久化需要新 storage schema；(c) prompt compile pipeline 是新子系統；(d) 4 個 worker pool 對 host event loop 影響面廣 |
+
+**文件估**: 12-21 週。**實算**: 20-31 週。**樂觀 30-50%**。
+
+### 19.3 文件漏寫的關鍵風險
+
+1. **Daytona OSS 沒擺脫 Docker** — 官方 OSS 部署是 Docker Compose stack，目前 EvoClaw 部署是 pm2 + `docker run`。換 Daytona 等於再加一層編排，運維面變大不變小。若不走 Daytona Cloud SaaS，就少了 Daytona 最大的「免運維」賣點。
+
+2. **Windows host 上的 Daytona 體驗未驗證** — Daytona 主推 Linux 雲端。本地 Windows 開發環境跑 Daytona OSS（Docker Desktop on WSL2 中又跑一層 Docker Compose 中再起 sandbox）的延遲、穩定性無第一手資料。MVP 階段建議先在 Linux/WSL2 host 驗 PoC。
+
+3. **無 regression 安全網** — repo 內 `python-tests` workflow 持續 hang 到 6h timeout（pre-existing）。這麼大規模的 runtime refactor 沒有自動 regression net 是高風險。建議 Phase 2 啟動前先補 `python-tests` 修綠（或起碼讓 critical-path 測試獨立執行）。
+
+4. **沒提到今天剛修的 issue** — `#583` (MEMORY.md XML leak)、`#584` (self_update 幻覺)、`#585` (repo 分析 parrot README)、`#586` (introspection OOM loop)、`#587` (#538 mitigation A+C)、`#588`–`#594` 都在 2026-05-14/15 merged。其中一部分「不順」感是這些 bug 造成的；流暢度量測（Phase 0）應在這些修完之後重新 baseline，避免錯把已修 bug 算進 runtime 模型問題。
+
+5. **#538 OOM 沒列為前置條件** — 文件假設「流暢度」與「OOM 頻率」可獨立處理。實際上 OOM-kill 是流暢度殺手（每次 OOM = 整輪訊息丟失 + 用戶看到錯誤訊息）。Phase 0 metrics 應同時量 TTFT/TTR 與 OOM rate，否則「流暢度改善」可能被 OOM 抵消。
+
+### 19.4 修正後的建議
+
+**立即啟動（低風險、解 50-70% 流暢度體感）**:
+- Phase 0 (3-5 天) — metrics 是無腦贏；先取得 baseline
+- Phase 1 (2-3 週) — queue priority、prompt slim、fast/balanced/deep 局部改、無架構風險
+
+**緩做（高風險、需先驗證）**:
+- Phase 2-4（Daytona + IPC + stateful runtime）— 5-7 個月實際投入
+- 前置條件：(a) Phase 0 metrics 有真實數字、(b) `python-tests` 修綠或補關鍵 regression、(c) Linux/WSL2 PoC 驗過 Daytona 體感勝過 `docker run`
+
+**該砍**:
+- Daytona OSS 自架方案 — 換湯不換藥（仍 Docker Compose）；要嘛走 Daytona Cloud SaaS 賭依賴，要嘛別走 Daytona。中間態最差。
+
+## 20. 12 個月決策節點
+
+不要把整個 Phase 0–4 當成一條必走的路。每個 phase 完成後設一個 go/no-go：
+
+| 節點 | 判斷依據 | Go 條件 | No-go 條件 |
+|---|---|---|---|
+| Phase 0 → 1 | metrics baseline | TTFT > 3s 或 OOM rate > 1/hr | 兩者都已達標，停在 Phase 0 觀察 |
+| Phase 1 → 2 | Phase 1 後體感量測 | TTFT 仍 > 1.5s 或用戶仍抱怨 | TTFT < 1.5s 且 4 週無新流暢度抱怨，停 Phase 1 |
+| Phase 2 → 3 | DaytonaRuntime MVP 與 DockerRuntime A/B | Daytona 路徑 TTFT 至少快 30% | Daytona 路徑慢於或等於 Docker，砍 Daytona、繼續 Docker + 改 IPC |
+| Phase 3 → 4 | IPC 事件化後 P95 latency | P95 仍 > 2s | P95 < 1.5s 且用戶滿意，停在 Phase 3 |
+
+每個節點 no-go 都是合法選項，不是失敗。
+
+## 21. 與其他文件的對照
+
+- `docs/PRODUCT_STRATEGY.md` 提出產品定位（群組型自治平台），技術路線必須服務此定位。若產品定位確定不打 coding agent 戰場，則 Phase 4「長駐 stateful runtime」的優先級高於「streaming UX」（後者偏 coding agent UX）。
+- `docs/ARCHITECTURE.md` 描述當前 v1.x file IPC 與計畫中 v2.x WebSocket。本文件 Phase 3 與該計畫對齊但更具體。
+- `docs/STABILITY_ANALYSIS.md` 列舉穩定性修補。Phase 0 metrics 不應只量延遲，也應記錄穩定性事件（OOM、container kill、IPC backpressure），否則「快」可能犧牲「穩」。
+
+## 22. 一句話結論
+
+原文件分析準確、方向正確。**Phase 0 + Phase 1 立刻做，Phase 2-4 緩做且設明確 no-go 節點。** Daytona 不是 silver bullet，是「runtime 模型升級」的一個候選實作；若 Phase 1 已解大半問題，Phase 2-4 可暫不啟動。

--- a/docs/PRODUCT_STRATEGY.md
+++ b/docs/PRODUCT_STRATEGY.md
@@ -1,0 +1,538 @@
+# EvoClaw 殺出重圍的產品戰略
+
+更新日期: 2026-05-15
+最近審視: 2026-05-15（加入可行性審視段，章節 14–17）
+
+## 1. 結論先講
+
+EvoClaw 不應該繼續朝「另一個更快的通用 coding agent」發展。
+
+那條路線會直接和 `nanoclaw`、`hermes agent`、Claude Code 類產品正面競爭，而 EvoClaw 現階段的系統優勢不在那裡。它的強項不是極致輕快的單回合互動，而是：
+
+- 長期運行
+- 多群組 / 多任務 orchestration
+- 記憶、規則、排程、治理
+- 可觀測、可管理、可演化
+
+因此 EvoClaw 的正確發展方向，不是成為更像 IDE coding assistant 的產品，而是成為：
+
+**可長期運行、可治理、可多角色協作的群組型自治 Agent 平台。**
+
+你前一輪提到的 `1 + 2`，應該直接定義成產品主軸：
+
+1. 群組型自治 Agent 平台
+2. 長任務運營型 Agent
+
+這兩條不是分開做，而是要合併成同一個核心敘事：
+
+**EvoClaw = Persistent Multi-Agent Operations Platform**
+
+更貼近中文產品語言可以表述為：
+
+**EvoClaw 是一個可長期運行的群組自治 Agent 作業平台，能在多人環境中持續執行任務、記住脈絡、遵守規則，並被管理者治理。**
+
+## 2. 為什麼不能正面拼通用 coding agent
+
+如果產品敘事停留在「會聊天、會改 code、會跑工具」，EvoClaw 會很難殺出來，原因有三個：
+
+1. 體感上，現有架構不是為最低延遲設計
+2. 市場上，通用 coding agent 的期待值已被更輕的產品定義
+3. 差異化上，EvoClaw 的稀缺能力其實在自治、治理、長任務，不在單回合聊天
+
+前一份技術分析 (`docs/FLUIDITY_AND_DAYTONA_PLAN.md`) 已經指出，目前流暢度受限於幾個結構性問題：
+
+- 每回合 `docker run` 的冷啟路徑
+- file IPC / polling
+- queue 與 scheduler 對前台互動的干擾
+- prompt 過胖
+- 長工具鏈與多輪 reasoning loop
+
+這些都可以改善，但即使改善後，EvoClaw 最有機會建立護城河的，仍然不是「和所有 coding agent 比誰更像 IDE 裡的即時助手」。
+
+## 3. 正確定位
+
+### 3.1 產品一句話
+
+**一個可長期運行、可管理、可多角色協作的群組自治 Agent 平台。**
+
+### 3.2 三個核心標籤
+
+產品訊息需要收斂成三個很容易理解的詞：
+
+- `Persistent`：不是一次性問答，而是持續運行
+- `Multi-Agent`：不是單 agent，而是可角色分工
+- `Governable`：不是黑盒，而是可管理、可審計、可控
+
+這三個標籤比「更快」、「更聰明」、「更多功能」更有辨識度。
+
+### 3.3 產品類別
+
+EvoClaw 不應定義成：
+
+- AI 聊天機器人
+- coding assistant
+- Discord bot framework
+
+更適合的類別是：
+
+- Agent Operating System
+- Multi-Agent Automation Platform
+- Autonomous Group Agent Runtime
+
+如果對外敘事要更務實，可以用：
+
+**Self-hostable Agent Operations Platform for Teams and Communities**
+
+## 4. 核心主軸：把 1 + 2 合併成真正的戰場
+
+### 4.1 主軸一：群組型自治 Agent 平台
+
+這條線代表 EvoClaw 不是服務單一使用者，而是服務一個群組、一個社群、一個團隊空間。
+
+典型能力包括：
+
+- 群組長期記憶
+- 多角色 agent 協作
+- 群規 / 回應規則 / 權限邏輯
+- 排程與持續巡檢
+- 對話之外的背景任務
+- 管理者介面與操作記錄
+
+這會讓 EvoClaw 和一般「聊天機器人」或「單人 coding agent」拉開距離。
+
+### 4.2 主軸二：長任務運營型 Agent
+
+這條線代表 EvoClaw 不是只在有人發問時才動，而是能持續執行任務與回報。
+
+典型能力包括：
+
+- 每日 / 每週巡檢
+- 情報蒐集與整理
+- 長步驟工作流
+- 背景執行後再回報
+- 多來源資訊整合
+- 狀態追蹤與失敗重試
+
+這是一般即時對話 agent 不一定擅長、但 EvoClaw 很適合發展的方向。
+
+### 4.3 為什麼 1 + 2 要綁在一起
+
+如果只有群組自治，產品容易被理解成「比較複雜的聊天 bot」。
+
+如果只有長任務運營，產品又容易被理解成「工作流排程器加 LLM」。
+
+把兩者綁起來，才會形成真正的差異化：
+
+**在群組 / 團隊場景中，長期自治地執行任務、累積記憶、接受治理、持續產出價值。**
+
+這是比「更像另一個 coding agent」更有防守力的定位。
+
+## 5. 目標客群
+
+不要一開始把所有人都當目標。應先鎖定最可能持續使用、且最能體現 EvoClaw 優勢的客群。
+
+### 5.1 第一優先客群
+
+- Telegram / Discord 社群經營者
+- 小型遠端團隊
+- 需要長期整理資訊的研究型團隊
+- 自架工具接受度高的技術型社群
+
+這些人共同特徵是：
+
+- 不是只想問答
+- 願意設規則
+- 需要持續運行
+- 願意接受 dashboard / 管理介面
+
+### 5.2 第二優先客群
+
+- 內容社群營運者
+- 顧問 / 研究 / 投資情報團隊
+- AI native startup 內部營運團隊
+
+### 5.3 暫時不要優先的客群
+
+- 只想要最快聊天回覆的一般使用者
+- 純 IDE coding assistant 使用者
+- 對部署與設定零容忍的非技術客群
+
+## 6. 差異化主張
+
+EvoClaw 要能用一句話說清楚，自己和主流 agent 有什麼不一樣。
+
+### 6.1 不要主打的差異
+
+以下敘事不夠強，也容易被更成熟產品壓過去：
+
+- 我們也能改 code
+- 我們也有工具調用
+- 我們也支援多模型
+- 我們也能聊天
+
+### 6.2 應該主打的差異
+
+真正值得打的差異是：
+
+- `長期自治`：不是問一次答一次，而是持續幫你做事
+- `群組原生`：不是只對一個人服務，而是服務一個共同空間
+- `治理能力`：不是不可控黑盒，而是可設規則、可追蹤、可管理
+- `可自架`：不是只能用 SaaS，而是能掌握資料與執行環境
+
+### 6.3 對外敘事範例
+
+可以考慮以下方向：
+
+`EvoClaw is not just an AI agent that answers. It is an agent system that keeps working.`
+
+中文版本：
+
+`EvoClaw 不是只會回答的 AI，而是一個會持續運作、可被治理的群組自治 Agent 系統。`
+
+## 7. 產品線設計
+
+不要只交付 framework，要交付「可直接用的方案包」。
+
+### 7.1 優先做的 3 個 Solution Pack
+
+#### A. Community Manager Agent
+
+適用於 Telegram / Discord 社群。
+
+能力包含：
+
+- 自動整理群聊重點
+- FAQ 回覆建議
+- 公告整理
+- 每日摘要
+- 關鍵議題追蹤
+- 管理者輔助
+
+#### B. Research Ops Agent
+
+適用於研究、投資、知識工作團隊。
+
+能力包含：
+
+- 追蹤主題
+- 每日彙整資訊
+- 長期建立知識庫
+- 定時生成 brief
+- 異常或新訊號提醒
+
+#### C. Team Operations Agent
+
+適用於小型團隊協作。
+
+能力包含：
+
+- 任務提醒
+- 例行巡檢
+- 文件整理
+- issue / commit / release note 彙整
+- 團隊知識脈絡保留
+
+### 7.2 為什麼要先做方案包
+
+如果只賣平台，使用者要先理解太多架構概念，導入成本高。
+
+如果先給 solution pack，使用者看到的是：
+
+- 具體場景
+- 立即價值
+- 可複製模板
+
+這會比單純展示框架能力更容易獲得 adoption。
+
+## 8. 產品取捨
+
+要殺出重圍，不能什麼都做。下面是建議的取捨。
+
+### 8.1 應優先投入
+
+- 長期自治能力
+- 多群組 / 多任務管理
+- 背景任務與前台對話分離
+- dashboard / 可觀測性
+- rule / memory / identity 管理
+- 部署與模板化
+
+### 8.2 應降優先
+
+- 和 IDE coding assistant 的正面功能對齊
+- 大量泛用聊天功能
+- 沒有場景指向的 agent 花式能力
+- 只服務單一使用者的互動設計
+
+### 8.3 需要補最低門檻
+
+雖然不該正面拼通用 agent，但這些底線還是要補，不然使用者根本不會留下：
+
+- 前台互動流暢度
+- token / progress streaming
+- 更簡單的安裝與部署
+- 更清楚的執行可見性
+- fast / balanced / deep 模式切換
+
+## 9. 與技術規劃的銜接
+
+前一份文件 `docs/FLUIDITY_AND_DAYTONA_PLAN.md` 解的是「怎麼變順、要不要用 Daytona、底層如何改」。
+
+這份產品戰略解的是「就算底層變順了，EvoClaw 應該往哪裡打」。
+
+兩份文件的關係應該是：
+
+- 技術規劃負責把體感拉到可用門檻
+- 產品戰略負責決定不要把可用門檻浪費在錯誤戰場
+
+換句話說：
+
+- **技術改善是必要條件**
+- **產品定位才是勝負手**
+
+## 10. 6 個月發展路線
+
+### Phase 1：重新定義產品敘事（第 1-4 週）
+
+目標：把 EvoClaw 從「功能很多的 agent 專案」改成「定位清楚的產品」。
+
+要做的事：
+
+- 確認對外一句話定位
+- 內部文件統一 `Persistent / Multi-Agent / Governable`
+- 官網 / README / Demo 敘事全部收斂
+- 明確放棄「另一個通用 coding agent」的表達
+
+交付物：
+
+- 新版 README
+- Landing page 文案
+- 3 個場景說明頁
+
+### Phase 2：補足可試用門檻（第 2-8 週）
+
+目標：讓使用者第一次用，不會先被笨重體感趕走。
+
+要做的事：
+
+- 依技術規劃先做流暢度快修
+- 提升前台互動優先級
+- prompt 瘦身
+- progress / token streaming
+- 安裝部署簡化
+
+核心衡量：
+
+- 首次回應速度
+- 安裝成功率
+- 首次設定完成率
+
+### Phase 3：推出 2-3 個 solution pack（第 2-4 個月）
+
+目標：從平台能力轉成具體價值。
+
+優先建議：
+
+- Community Manager Agent
+- Research Ops Agent
+- Team Operations Agent
+
+核心衡量：
+
+- 每個方案是否能在 30 分鐘內部署
+- 是否能在 3 天內產出明顯價值
+- 是否能形成可重複使用模板
+
+### Phase 4：強化長期運行能力（第 3-5 個月）
+
+目標：把 EvoClaw 從「能跑」升級到「適合長期掛著」。
+
+要做的事：
+
+- 背景任務與前台對話分離
+- 更好的 runtime session 保持
+- 多 agent 分工與狀態顯示
+- 失敗重試與觀測強化
+- 管理者治理流程完善
+
+### Phase 5：驗證真正 PMF 訊號（第 5-6 個月）
+
+目標：找出哪個場景最有機會成為主產品。
+
+要看的指標：
+
+- 每週活躍群組數
+- 每群背景任務執行次數
+- 每群每週被主動打開 dashboard 的次數
+- retention
+- 管理者設定完成率
+- 模板重複部署數
+
+## 11. 商業模式方向
+
+商業化不要太晚想，因為產品定位會直接影響技術路線。
+
+### 11.1 最合理的三種模式
+
+#### A. Open-source core + hosted management
+
+開源核心，收費在：
+
+- 管理介面
+- 託管 runtime
+- 團隊管理能力
+- 可觀測與治理套件
+
+#### B. Self-hosted enterprise
+
+適合重視資料與合規的團隊，收費在：
+
+- 企業部署
+- 管理功能
+- 進階權限治理
+- 支援服務
+
+#### C. Solution pack / template marketplace
+
+如果場景跑出來，可以賣：
+
+- 產業模板
+- agent pack
+- workflow pack
+- 管理策略包
+
+### 11.2 與 Daytona / runtime 路線的關係
+
+如果未來真的往 Daytona 或長駐 sandbox runtime 發展，就有條件延伸成：
+
+- hosted sandbox
+- managed session runtime
+- team agent hosting
+
+但這要建立在產品定位已經清楚，不然只會變成更昂貴的基礎設施負擔。
+
+## 12. 最重要的三個戰略原則
+
+### 原則一：不要做另一個更快的 Claude Code
+
+那會把你帶去最擁擠、最難贏、而且不符合現有資產的戰場。
+
+### 原則二：用「群組自治 + 長任務運營」組成真正差異化
+
+這是你指定的 `1 + 2`，也是這份策略的核心。
+
+它讓 EvoClaw 從聊天工具，升級成持續運作的 agent 系統。
+
+### 原則三：技術改善是為了支撐定位，不是取代定位
+
+流暢度一定要補，但補流暢度不是為了證明自己也能當通用 coding agent，而是為了讓核心產品價值能被真正使用。
+
+## 13. 一句話版結論
+
+EvoClaw 最有機會殺出重圍的方式，不是做成「另一個更快的 agent」，而是做成：
+
+**一個可長期運行、可治理、可多角色協作的群組自治 Agent 平台，專門處理群組場景中的長任務與持續運營。**
+
+---
+
+## 14. 可行性審視（2026-05-15 加入）
+
+本章對照當前 repo `keepinmind2054/evoclaw` 主分支 HEAD `e999603` 之後的 code，逐項驗證戰略賣點背後的實作支撐度。
+
+### 14.1 三個核心標籤的 code 支撐
+
+| Strategy 賣點 | Code 現況 | Gap |
+|---|---|---|
+| **Persistent (長駐)** | `host/db.py` 內 `scheduled_tasks` 表存在；`host/task_scheduler.py` 60s 輪詢；支援 cron / interval / once | session continuity 弱 — 每 turn cold container（見 `FLUIDITY_AND_DAYTONA_PLAN.md` Phase 4） |
+| **Multi-Agent** | `container/agent-runner/_tools.py` 提供 `mcp__evoclaw__run_agent` 工具；可 spawn subagent | 實際生產 workflow 沒見到多 agent 協作的成熟用例，多用於 single-agent + 偶發 subagent delegation |
+| **Governable** | `host/identity/bot_registry.py` + `host/rbac/roles.py` 已存；dashboard `host/dashboard.py` 在 port 8765 | Admin UX 簡陋（基本 CRUD 介面，缺 audit log timeline、規則 DSL 編輯器、訊息搜尋） |
+| **Group-native** | `registered_groups` table；per-group folder + `MEMORY.md` + `CLAUDE.md`；JID 格式 `tg:` / `wa:` / `dc:` 等 | ✓ 真有，是 EvoClaw 強項 |
+| **5-layer Memory** | README 宣稱 Hot → PalaceStore → Vector → Shared → Cold + KnowledgeGraph | `host/memory/` 有 `hot.py`、`warm.py`、`memory_bus.py`、`summarizer.py`、`vector_ingestor.py`、`dream_task.py` — 大部分零件在，但 PalaceStore / KnowledgeGraph 對應檔案薄弱，README 用詞超過 code 現況（參考 issue #585 已開）|
+| **Skills 2.0** | README 宣稱熱抽換容器工具 | `data/dynamic_tools` mount 機制存在；實際 skill marketplace / 載入流程是 minimal viable |
+| **DevEngine 7 階段** | README 宣稱 | `host/dev_engine` 不存在；`tests/test_dev_engine.py` 有測但對應實作待考 — README aspirational |
+
+**結論**: 群組原生 + 排程 + 多後端 + RBAC + dashboard 真有，是強項。但 5-layer memory / KnowledgeGraph / DevEngine / Skills 2.0 在 README 中的呈現超過 code 的成熟度。戰略文件若繼續引用這些賣點，必須補 code 或調整 README（與 `#585` 同一條線）。
+
+### 14.2 Solution Pack 可行性
+
+每個 Pack 的「30 分鐘部署、3 天看到價值」標準很激進。對照零件存量：
+
+| Pack | 既有零件支持度 | 缺什麼 | 估開發量 |
+|---|---|---|---|
+| Community Manager | `host/channels/telegram_channel.py` + `discord_channel.py` + `task_scheduler` + `host/evolution/immune.py` (anti-injection)；訊息存 SQLite | 對話摘要 prompt 範本；群規 DSL（目前只有 free-form `CLAUDE.md`）；FAQ store；公告整理工作流 | **50-80 小時** |
+| Research Ops | `WebFetch` tool + `task_scheduler` + `host/memory` + `host/memory/summarizer` | RSS / source 訂閱機制（目前沒）；brief 模板；信號偵測規則；長期知識庫的 indexing pipeline | **80-150 小時** |
+| Team Operations | `host/enterprise/jira_connector.py` + GitHub 認證 + `task_scheduler` | issue 彙整 prompt；release-note 模板；commit/PR 抓取流程；團隊知識保留 schema | **60-100 小時** |
+
+3 個 Pack 合計 **190-330 小時** (5-8 週純開發)。Strategy 把這個排在第 2-4 個月，時程合理但要全職投入。
+
+**「30 分鐘內部署」風險**: 目前 setup 流程是 `python setup/setup.py` + 編輯 `.env` (今天剛擴成 57+ vars 見 PR #582) + `python scripts/register_group.py` + `docker build`。新手照做超過 30 分鐘無懸念。若要達標需做 setup wizard CLI 或 web onboarding flow，這本身是 30-50 小時工程。
+
+### 14.3 商業模式時程的合理性
+
+文件 11.1 列三種模式 (OSS core + hosted management、self-hosted enterprise、template marketplace)，但放在 6 個月路線的後半。
+
+實算：
+
+- OSS core + hosted management 需要：(a) 穩定的 hosted runtime infra (=Phase 2-4 of fluidity plan, 5-7 個月)、(b) 計費 + 訂閱系統（新建）、(c) onboarding flow、(d) 客服。**12 個月內可成形是樂觀**。
+- Self-hosted enterprise 需要：(a) 企業 packaging (helm chart / docker-compose distro)、(b) SSO / SAML、(c) audit log、(d) license server。**現有 RBAC + identity 是好起點但企業特性差距大**。
+- Solution Pack marketplace 需要：(a) 至少 3 個 reference pack 上線且有真實 user、(b) pack 安裝協議、(c) 收費機制。**最依賴前面 Phase 跑通**。
+
+**結論**: 商業模式正確，但時程估計過於樂觀。6 個月內可做到的：定位收斂 + 1-2 個 Pack 上線 + 早期 user 訪談。**6 個月內到收費階段不現實**，建議調整為「6 個月驗 PMF，12-18 個月開始收費」。
+
+### 14.4 文件漏寫的關鍵風險
+
+1. **「不拼 coding agent」與既有 code framing 的矛盾** — README 大量內容是 coding 場景（DevEngine 7 階段、Skills 熱抽換、agent.py tool loop 預設值針對 code task）。要轉成「群組自治」敘事必須砍 README 大半篇幅、重寫 onboarding、調整 default prompts。Phase 1 (1-4 週) 內要做完這些工程量不小，估 **40-60 小時**。
+
+2. **OOM / 流暢度問題還在** — 2026-05-13 telegram transcript 顯示 2 小時內 8 次 OOM。產品戰略文件假設「使用者進來」後體驗順暢，但目前真實情況是用戶看到 `⚠️ 記憶體不足` 訊息頻率不低。今天 PR #587 / #588 / #589 / #591 / #594 修了根因的一部分，但 24 小時 baseline 還沒回收。Phase 2「補足可試用門檻」是整個戰略能落地的前置條件，不是並行項目。
+
+3. **「30 分鐘部署」與當前 setup 矛盾** — 上一節已說。要達標需先做 setup wizard。
+
+4. **OSS competitor 已存在** — Strategy 提的「Persistent Multi-Agent Operations Platform」品類正在被多個 OSS 專案搶（LangGraph 的 long-running agents、AutoGen team mode、CrewAI flows、OpenHands persistent sessions）。文件沒分析 EvoClaw vs 這些的差異。**Governable + Self-hostable + Group-native 是值得打的角度，但需要明確 positioning vs 各 OSS 比較**。
+
+5. **「群組」=「Telegram / Discord 群」 的範式可能受限** — 企業客戶用 Slack / Teams / Lark 居多；Telegram / Discord 偏 indie / 社群。客群選擇影響商業天花板。文件鎖定 Telegram / Discord 是合理的 beachhead，但商業化時要評估是否擴到企業 IM。
+
+### 14.5 修正後的優先序
+
+立即啟動（無風險、立即見效）：
+- **改 README + landing 敘事** — 1 週工程量，砍 coding-agent 賣點、補 Persistent/Multi-Agent/Governable 三標籤。Zero code risk。
+
+緊接著（順著今天技術修補）：
+- **流暢度量測 baseline** — `FLUIDITY_AND_DAYTONA_PLAN.md` Phase 0，3-5 天。產品戰略不能在沒有 baseline 的情況下談「使用者體驗順暢」。
+- **Phase 1 流暢度快修** — 2-3 週。為 Solution Pack 上線打底。
+
+緩做：
+- **Solution Pack 開發** — 等 Phase 1 完成 + setup wizard 有雛形再啟動。否則第一個 user 進來看到 OOM 就跑。
+- **商業模式具體化** — 6 個月後再談。先驗 PMF 訊號。
+
+該砍：
+- 12 個月內到「收費」的計畫 — 過於樂觀，建議調為「12-18 個月」。
+- 「3 個 Solution Pack 同時做」— 集中資源做 1 個，跑通後複製。建議先做 Community Manager（門檻最低、即時回饋最快）。
+
+## 15. 與技術文件的對照節點
+
+| 戰略需求 | 對應技術項 (FLUIDITY plan) | 是否阻擋 |
+|---|---|---|
+| 「使用者進來不會被笨重體感趕走」 | Phase 0 (metrics) + Phase 1 (quick wins) | 是 — 必須先做 |
+| 「長期掛著」 | Phase 4 (long-lived runtime) | 中 — 不做也能跑，但流暢度有上限 |
+| 「多 agent 分工」 | 已存 (`run_agent` IPC)，但需 streaming UX 才好用 | 否 — Phase 3 (event IPC) 之後再強化 |
+| 「治理 / RBAC / audit」 | 已存基礎；需 dashboard UX 強化 | 否 — 獨立 sprint 即可 |
+| 「Solution Pack 30 分鐘部署」 | 不在 fluidity plan 範圍 — 需獨立 setup wizard 工作 | 是 — 影響 Phase 3 of strategy |
+
+## 16. 6 個月路線的修正版
+
+不改大方向，調整時程與並行度：
+
+| 月份 | 戰略 Phase | 技術 Phase | 主要交付 |
+|---|---|---|---|
+| Month 1 | Strategy Phase 1 (敘事收斂) | Fluidity Phase 0 + Phase 1 | 新 README + landing；metrics baseline；prompt slim；fast/balanced/deep |
+| Month 2 | Strategy Phase 2 (可試用門檻) | Fluidity Phase 1 收尾 | setup wizard MVP；TTFT < 2s baseline 達標 |
+| Month 3 | Strategy Phase 3 (1st Solution Pack — Community Manager) | (持平) | Community Manager v1 上線 |
+| Month 4 | Strategy Phase 3 (Pack 反饋迭代) | Fluidity Phase 2 啟動條件評估 | 5-10 個真實 user；OSS reference deployment |
+| Month 5 | Strategy Phase 4 (長期運行強化) | Fluidity Phase 2-3（若 go） | 背景/前台分流；可選的 Daytona PoC |
+| Month 6 | Strategy Phase 5 (PMF 訊號驗證) | (持平) | retention + 使用量數據；下半年計畫制定 |
+
+**關鍵差異**: 不在 6 個月內 ship 3 個 Pack；不在 6 個月內談收費；不在 6 個月內完成 Daytona 遷移。一切收斂在「敘事 + 流暢度 + 1 個跑得通的 Pack」三件事。
+
+## 17. 一句話結論
+
+原文件方向正確，戰略選擇合理。**但時程估計過樂觀，且假設了「使用者體驗順暢」的前置條件尚未達成。** 立即啟動的是「重 README + 流暢度 metrics + 1 個 Solution Pack」三件套，其餘緩做或砍掉。


### PR DESCRIPTION
## Summary

Imports two strategic planning docs that existed only in a sibling repo, and adds a code-grounded feasibility audit to each.

### Files added

| File | Purpose |
|---|---|
| `docs/FLUIDITY_AND_DAYTONA_PLAN.md` | Technical plan: why per-turn `docker run` feels slow, 4-phase migration to long-lived runtime, optional Daytona evaluation. Audit added in §19-22. |
| `docs/PRODUCT_STRATEGY.md` | Product positioning as *Persistent Multi-Agent Operations Platform*. Audit added in §14-17. |

### What the audit sections do

**FLUIDITY (§19-22):**
- Verifies every code citation against `host/` and `container/agent-runner/` HEAD.
- Re-estimates phase timelines:
  - Phase 0 metrics: 3-5 days (matches)
  - Phase 1 quick wins: 1-2w → **2-3w**
  - Phase 2 AgentRuntime + Daytona MVP: 3-6w → **4-8w**
  - Phase 3 kill file IPC: 3-5w → **6-8w**
  - Phase 4 long-lived runtime: 4-8w → **8-12w**
  - **Total: 12-21w original → 20-31w realistic (30-50% optimistic)**
- Flags 5 risks the original missed:
  1. Daytona OSS is itself Docker Compose — doesn't escape Docker
  2. Untested on Windows host (Daytona targets Linux cloud)
  3. No regression net (python-tests workflow hangs to 6h timeout — pre-existing)
  4. Ignored today's `#583`/`#584`/`#585`/`#586`/`#587`-`#594` fixes which already address part of the "not fluid" feel
  5. `#538` OOM frequency not baselined — flushing-cgroup-OOM is a fluidity killer too
- Adds explicit go/no-go decision nodes between phases (no phase is blindly required).

**STRATEGY (§14-17):**
- Maps each strategy claim against real modules:
  - `Persistent / Multi-Agent / Governable / Group-native` — code supports
  - `5-layer Memory / Skills 2.0 / DevEngine 7 階段` — README rhetoric exceeds code maturity (parks on `#585`)
- Estimates Solution Pack effort: 50-150h each, 190-330h for 3 → 5-8w full-time
- Flags that "30-minute deployment" target is incompatible with current `python setup/setup.py + .env + register_group.py + docker build` flow (needs a setup wizard first, additional 30-50h)
- Notes OSS competitors in the same category (LangGraph long-running, AutoGen team mode, CrewAI flows, OpenHands persistent) — original doc didn't position against them
- Recommends 6-month plan revision: ship ONE Pack (Community Manager) not three; defer revenue talk from 6mo → 12-18mo

### Why this matters

- Both docs were ungrounded in current code; readers would have implemented against aspirational claims.
- The audit grounds every claim and surfaces hidden dependencies (`#538`, `#585`, python-tests CI).
- Future technical / product decisions now have a versioned reference inside the EvoClaw repo, not a sibling project.

## Test plan

- [x] `git diff` reviewed — two new files + CHANGELOG entry
- [x] Both docs render in GitHub markdown preview
- [x] All cross-references (`#NNN` issues, file paths) verified
- [x] `_redact_url_secrets` not affected (no host code changed)

Closes #595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)