### PR TITLE
obs(host): add phase-0 latency and prompt instrumentation (#601)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # EvoClaw
 
+## Runtime Observability
+
+EvoClaw now emits Phase 0 timing and prompt-size logs on the hot execution path so latency work can be measured instead of guessed.
+
+- `phase0.message_batch`: request timing, queue timing, prompt length, message counts
+- `phase0.prompt_metrics`: input JSON size plus history / scheduled-task / hot-memory sizing
+- `phase0.first_progress`: time-to-first-progress (`ttft_ms`) when the agent emits its first stderr/progress line
+- `phase0.run_complete`: end-of-run timing for success / timeout / error paths
+
+These events are emitted by `host/main.py`, `host/group_queue.py`, and `host/container_runner.py` and are intended to support follow-up work on queue prioritization and prompt slimming.
+
 [![Version](https://img.shields.io/badge/version-v1.35.0-blue)](https://github.com/KeithKeepGoing/evoclaw/blob/main/docs/CHANGELOG.md)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2038,3 +2038,19 @@ register_dynamic_tool(
 | 1.10.0 | 2026-03-10 | 完整進化引擎、DevEngine、健康監控器 |
 | 1.9.0 | 2026-02-15 | 增強免疫系統、適應性進化 |
 | 1.8.0 | 2026-02-01 | 技能引擎、WhatsApp 支援 |
+## [1.27.40] - 2026-05-18
+
+### Added
+- **Phase 0 latency + prompt instrumentation for the interactive run path (#601).** `host/group_queue.py` now carries real queue timing metadata (`queued_at_ms`, `started_at_ms`, `queue_wait_ms`) into each execution. `host/main.py` logs per-batch request/queue context under `phase0.message_batch`. `host/container_runner.py` logs prompt-size metrics (`input_json_bytes`, history/task/memory sizes), first-progress timing (`phase0.first_progress`, `ttft_ms` when available), and terminal run summaries (`phase0.run_complete`) across success / timeout / error paths.
+
+### Why this matters
+- The repo has several plausible latency sources, but they were not measured end-to-end before this change.
+- Phase 1 work such as queue prioritization and prompt slimming now has a baseline instead of relying on intuition.
+- Queue wait is now recorded from the real scheduler path rather than reconstructed later in the request flow.
+
+### Technical Details
+- **Modified Files**: `host/main.py`, `host/group_queue.py`, `host/container_runner.py`.
+- **Image rebuild required**: No (host-side instrumentation only).
+- **Local verification**: `python -m py_compile host/main.py host/container_runner.py host/group_queue.py`.
+- **Breaking Changes**: None.
+- Closes #601.

--- a/host/container_runner.py
+++ b/host/container_runner.py
@@ -459,6 +459,7 @@ async def run_container_agent(
     conversation_history: list | None = None,
     parent_container: Optional[str] = None,
     on_error: Optional[Callable[[str], Awaitable[None]]] = None,
+    trace_context: Optional[dict] = None,
 ) -> dict:
     """
     在獨立的 Docker container 中執行 agent，並等待結果。
@@ -488,6 +489,8 @@ async def run_container_agent(
                 log.debug("on_error callback raised: %s", _ne)
 
     folder = group["folder"]
+    trace_context = trace_context or {}
+    turn_id = trace_context.get("turn_id", "")
 
     _circuit_remaining = _docker_circuit_open(folder)
     if _circuit_remaining:
@@ -594,14 +597,39 @@ async def run_container_agent(
         "runId": run_id,  # 關聯 ID：供 container 在 stderr 中記錄，與 host 日誌對齊
         "hotMemory": hot_memory,  # 三層記憶：熱記憶（8KB MEMORY.md，每次對話自動注入）
         "agentId": _agent_id,  # Phase 2 (UnifiedClaw): stable agent_id for FitnessReporter
+        "traceContext": trace_context,
     }
     # BUG-CR-03 FIX (LOW): use ensure_ascii=False so Chinese characters in
     # prompt / hot_memory are serialised as UTF-8 rather than \uXXXX escape
     # sequences.  The container reads stdin as UTF-8, so compact encoding is
     # both correct and significantly smaller for CJK content.
     input_json = json.dumps(input_data, ensure_ascii=False)
+    effective_history = conversation_history if conversation_history is not None else conv_history
+    prompt_metrics = {
+        "prompt_chars": len(prompt),
+        "input_json_bytes": len(input_json.encode("utf-8")),
+        "conversation_history_count": len(effective_history),
+        "conversation_history_chars": sum(len(str(m.get("content", ""))) for m in effective_history),
+        "scheduled_task_count": len(scheduled_tasks),
+        "scheduled_task_chars": len(json.dumps(scheduled_tasks, ensure_ascii=False)),
+        "hot_memory_chars": len(hot_memory or ""),
+        "hot_memory_bytes": len((hot_memory or "").encode("utf-8")),
+        "evolution_hints_chars": len(evolution_hints or ""),
+    }
     # 記錄 container 啟動時間，用於計算回應時間（適應度追蹤）
     t0 = time.time()
+    log.info(
+        "phase0.prompt_metrics",
+        extra={
+            "event": "phase0_prompt_metrics",
+            "run_id": run_id,
+            "turn_id": turn_id,
+            "jid": jid,
+            "folder": folder,
+            **trace_context,
+            **prompt_metrics,
+        },
+    )
     async with _get_active_lock():
         _active_containers[container_name] = {
             "name": container_name,
@@ -695,6 +723,7 @@ async def run_container_agent(
 
     proc = None       # asyncio subprocess reference — used for direct kill on CancelledError
     _win_exit_code: int | None = None  # Windows-only: returncode from subprocess.run()
+    first_progress_at_ms: int | None = None
     # p16c BUG-FIX (CRITICAL): stderr_lines must be initialised at function scope
     # before the platform branch.  On Windows the subprocess is run via
     # asyncio.to_thread(), so the Linux-only _stream_stderr() closure that
@@ -768,6 +797,7 @@ async def run_container_agent(
 
             async def _stream_stderr() -> None:
                 """逐行讀取 stderr 並更新 current_activity + log_buffer。"""
+                nonlocal first_progress_at_ms
                 assert proc.stderr is not None
                 _EMOJI_TAGS = ("🚀","📥","💬","🤖","🧠","🔧","📨","📎","📤","❌","🏁","⚠️")
                 while True:
@@ -780,6 +810,25 @@ async def run_container_agent(
                         break
                     line = line_bytes.decode(errors="replace").rstrip()
                     if line:
+                        if first_progress_at_ms is None:
+                            first_progress_at_ms = int(time.time() * 1000)
+                            _request_received_at_ms = trace_context.get("request_received_at_ms")
+                            _ttft_ms = None
+                            if _request_received_at_ms:
+                                _ttft_ms = max(0, first_progress_at_ms - int(_request_received_at_ms))
+                            log.info(
+                                "phase0.first_progress",
+                                extra={
+                                    "event": "phase0_first_progress",
+                                    "run_id": run_id,
+                                    "turn_id": turn_id,
+                                    "jid": jid,
+                                    "folder": folder,
+                                    "first_progress_at_ms": first_progress_at_ms,
+                                    "ttft_ms": _ttft_ms,
+                                    **trace_context,
+                                },
+                            )
                         if len(stderr_lines) < _MAX_STDERR_LINES:
                             stderr_lines.append(line)
                         elif len(stderr_lines) == _MAX_STDERR_LINES:
@@ -1073,7 +1122,26 @@ async def run_container_agent(
         # container 成功完成：通知呼叫方可以安全推進游標
         # 這是 rollback 安全機制的最後一步 — 只有到這裡才確認「已處理完畢」
         response_ms = int((time.time() - t0) * 1000)
-        # 記錄成功執行數據到演化引擎（適應度追蹤）
+        _request_received_at_ms = trace_context.get("request_received_at_ms")
+        _ttft_ms = None
+        if first_progress_at_ms and _request_received_at_ms:
+            _ttft_ms = max(0, first_progress_at_ms - int(_request_received_at_ms))
+        log.info(
+            "phase0.run_complete",
+            extra={
+                "event": "phase0_run_complete",
+                "run_id": run_id,
+                "turn_id": turn_id,
+                "jid": jid,
+                "folder": folder,
+                "status": "success",
+                "response_ms": response_ms,
+                "first_progress_at_ms": first_progress_at_ms,
+                "ttft_ms": _ttft_ms,
+                **trace_context,
+                **prompt_metrics,
+            },
+        )
         record_run(jid, run_id, response_ms, retry_count=0, success=True)
         safe_stderr = _redact_secrets(stderr) if stderr else ""
         stdout_preview = stdout[:200] if stdout else ""
@@ -1155,6 +1223,26 @@ async def run_container_agent(
                 pass
         # 記錄超時失敗數據（適應度扣分）
         _timeout_ms = int(config.CONTAINER_TIMEOUT * 1000)
+        _request_received_at_ms = trace_context.get("request_received_at_ms")
+        _ttft_ms = None
+        if first_progress_at_ms and _request_received_at_ms:
+            _ttft_ms = max(0, first_progress_at_ms - int(_request_received_at_ms))
+        log.info(
+            "phase0.run_complete",
+            extra={
+                "event": "phase0_run_complete",
+                "run_id": run_id,
+                "turn_id": turn_id,
+                "jid": jid,
+                "folder": folder,
+                "status": "timeout",
+                "response_ms": _timeout_ms,
+                "first_progress_at_ms": first_progress_at_ms,
+                "ttft_ms": _ttft_ms,
+                **trace_context,
+                **prompt_metrics,
+            },
+        )
         record_run(jid, run_id, _timeout_ms, retry_count=0, success=False)
         db.log_container_finish(run_id, time.time(), "timeout", "Container timed out", "", _timeout_ms)
         _record_docker_failure(folder)
@@ -1185,7 +1273,26 @@ async def run_container_agent(
     except Exception as e:
         log.error("Container %s error: %s", folder, e)
         response_ms = int((time.time() - t0) * 1000)
-        # 記錄異常失敗數據
+        _request_received_at_ms = trace_context.get("request_received_at_ms")
+        _ttft_ms = None
+        if first_progress_at_ms and _request_received_at_ms:
+            _ttft_ms = max(0, first_progress_at_ms - int(_request_received_at_ms))
+        log.info(
+            "phase0.run_complete",
+            extra={
+                "event": "phase0_run_complete",
+                "run_id": run_id,
+                "turn_id": turn_id,
+                "jid": jid,
+                "folder": folder,
+                "status": "error",
+                "response_ms": response_ms,
+                "first_progress_at_ms": first_progress_at_ms,
+                "ttft_ms": _ttft_ms,
+                **trace_context,
+                **prompt_metrics,
+            },
+        )
         record_run(jid, run_id, response_ms, retry_count=0, success=False)
         db.log_container_finish(run_id, time.time(), "error", str(e), "", response_ms)
         _record_docker_failure(folder)

--- a/host/group_queue.py
+++ b/host/group_queue.py
@@ -91,11 +91,11 @@ class GroupQueue:
         self._active_count: int = 0                 # 目前正在執行的 container 總數
         self._waiting_groups: collections.deque = collections.deque()  # 等待 concurrency 槽位的群組 JID 清單（FIFO, O(1) popleft）
         self._waiting_set: set = set()              # O(1) membership check for _waiting_groups (issue #446)
-        self._process_messages_fn: Optional[Callable[[str], Awaitable[bool]]] = None
+        self._process_messages_fn: Optional[Callable[[str, dict], Awaitable[bool]]] = None
         self._shutting_down: bool = False
         self._retry_tasks: set = set()
 
-    def set_process_messages_fn(self, fn: Callable[[str], Awaitable[bool]]) -> None:
+    def set_process_messages_fn(self, fn: Callable[[str, dict], Awaitable[bool]]) -> None:
         """
         Register the coroutine to call when messages need processing.
         fn(group_jid) -> bool (True = success, False = retry)
@@ -127,6 +127,8 @@ class GroupQueue:
 
         if state.active:
             # 有 container 正在跑，先標記等下次排程
+            if state.pending_message_queued_at_ms is None:
+                state.pending_message_queued_at_ms = int(time.time() * 1000)
             state.pending_messages = True
             log.debug(f"[{group_jid}] Container active — message queued")
             return
@@ -135,12 +137,16 @@ class GroupQueue:
             # 有重試已排程中（指數退避等待中），不要立即再啟動新 container。
             # 只標記 pending_messages，讓排程重試到期後自然觸發處理。
             # 這防止 Docker circuit breaker 開路時形成緊密無限重試迴圈。
+            if state.pending_message_queued_at_ms is None:
+                state.pending_message_queued_at_ms = int(time.time() * 1000)
             state.pending_messages = True
             log.debug(f"[{group_jid}] Retry pending (count={state.retry_count}) — message queued, not starting new run")
             return
 
         if self._active_count >= config.MAX_CONCURRENT_CONTAINERS:
             # 全域並發已滿，加入等待佇列（FIFO，避免飢餓）
+            if state.pending_message_queued_at_ms is None:
+                state.pending_message_queued_at_ms = int(time.time() * 1000)
             state.pending_messages = True
             if group_jid not in self._waiting_set:  # O(1) membership check (issue #446)
                 if len(self._waiting_groups) < MAX_WAITING_GROUPS:
@@ -157,8 +163,10 @@ class GroupQueue:
         # 條件都滿足，同步更新狀態後建立 asyncio task（避免 race：多個 task 排入前計數來不及更新）
         state.active = True
         self._active_count += 1
+        _queued_at_ms = state.pending_message_queued_at_ms or int(time.time() * 1000)
+        state.pending_message_queued_at_ms = None
         t = asyncio.create_task(
-            self._run_for_group(group_jid, reason="messages"),
+            self._run_for_group(group_jid, reason="messages", queued_at_ms=_queued_at_ms),
             name=f"group-msg-{group_jid}",
         )
         t.add_done_callback(_task_done_callback)
@@ -249,7 +257,7 @@ class GroupQueue:
 
     # ── Internal runners ──────────────────────────────────────────────────────
 
-    async def _run_for_group(self, group_jid: str, reason: str) -> None:
+    async def _run_for_group(self, group_jid: str, reason: str, queued_at_ms: int | None = None) -> None:
         """
         實際執行「訊息回覆」container 的內部方法。
         標記群組為 active、增加全域計數，執行完畢後自動呼叫 _drain_group
@@ -265,7 +273,14 @@ class GroupQueue:
 
         try:
             if self._process_messages_fn:
-                success = await self._process_messages_fn(group_jid)
+                started_at_ms = int(time.time() * 1000)
+                effective_queued_at_ms = queued_at_ms or started_at_ms
+                success = await self._process_messages_fn(group_jid, {
+                    "reason": reason,
+                    "queued_at_ms": effective_queued_at_ms,
+                    "started_at_ms": started_at_ms,
+                    "queue_wait_ms": max(0, started_at_ms - effective_queued_at_ms),
+                })
                 if success:
                     state.retry_count = 0  # 成功後重置退避計數
                 else:
@@ -387,10 +402,12 @@ class GroupQueue:
                 # 這防止 Docker circuit breaker 開路時 _drain_group 形成緊密迴圈。
                 log.debug(f"[{group_jid}] Retry pending in drain — deferring message processing")
                 return
+            _queued_at_ms = state.pending_message_queued_at_ms or int(time.time() * 1000)
+            state.pending_message_queued_at_ms = None
             state.active = True
             self._active_count += 1
             t = asyncio.create_task(
-                self._run_for_group(group_jid, reason="drain"),
+                self._run_for_group(group_jid, reason="drain", queued_at_ms=_queued_at_ms),
                 name=f"group-msg-{group_jid}",
             )
             t.add_done_callback(_task_done_callback)
@@ -441,10 +458,12 @@ class GroupQueue:
                 # pending_messages=True and enqueue a duplicate run.  Clear it now
                 # (synchronously, before creating the task) to prevent double-dispatch.
                 state.pending_messages = False
+                _queued_at_ms = state.pending_message_queued_at_ms or int(time.time() * 1000)
+                state.pending_message_queued_at_ms = None
                 state.active = True
                 self._active_count += 1
                 t = asyncio.create_task(
-                    self._run_for_group(next_jid, reason="waiting"),
+                    self._run_for_group(next_jid, reason="waiting", queued_at_ms=_queued_at_ms),
                     name=f"group-msg-{next_jid}",
                 )
                 t.add_done_callback(_task_done_callback)

--- a/host/main.py
+++ b/host/main.py
@@ -715,7 +715,7 @@ async def _on_message(jid: str, sender: str, sender_name: str, content: str,
 
 
 async def _process_group_messages(group: dict, messages: list[dict],
-                                   on_success=None) -> None:
+                                  on_success=None, queue_meta: dict | None = None) -> None:
     """
     將一批訊息格式化後交給 container 執行。
 
@@ -725,6 +725,8 @@ async def _process_group_messages(group: dict, messages: list[dict],
     """
     folder = group["folder"]
     jid = group["jid"]
+    queue_meta = queue_meta or {}
+    turn_id = str(uuid.uuid4())
 
     # Phase 1 (UnifiedClaw): Track agent identity per group
     try:
@@ -819,6 +821,32 @@ async def _process_group_messages(group: dict, messages: list[dict],
 
     # Capture prompt text for warm memory logging (join all new message contents)
     _user_prompt_text = " ".join(m.get("content", "") for m in messages if m.get("content", "").strip())
+    request_received_at_ms = max((int(m.get("timestamp", 0) or 0) for m in messages), default=int(time.time() * 1000))
+    trace_context = {
+        "turn_id": turn_id,
+        "request_received_at_ms": request_received_at_ms,
+        "queued_at_ms": queue_meta.get("queued_at_ms"),
+        "queue_started_at_ms": queue_meta.get("started_at_ms"),
+        "queue_wait_ms": queue_meta.get("queue_wait_ms"),
+        "queue_reason": queue_meta.get("reason", "unknown"),
+    }
+    log.info(
+        "phase0.message_batch",
+        extra={
+            "event": "phase0_message_batch",
+            "turn_id": turn_id,
+            "jid": jid,
+            "folder": folder,
+            "message_count": len(messages),
+            "conversation_history_count": len(conversation_history),
+            "prompt_chars": len(prompt),
+            "request_received_at_ms": request_received_at_ms,
+            "queued_at_ms": queue_meta.get("queued_at_ms"),
+            "queue_started_at_ms": queue_meta.get("started_at_ms"),
+            "queue_wait_ms": queue_meta.get("queue_wait_ms"),
+            "queue_reason": queue_meta.get("reason", "unknown"),
+        },
+    )
 
     async def on_output(text: str):
         # 將 container 的回覆透過 router 發送回對應的聊天室
@@ -960,6 +988,7 @@ async def _process_group_messages(group: dict, messages: list[dict],
                 session_id=session_id,
                 on_success=_on_success_tracked,
                 on_error=on_error,
+                trace_context=trace_context,
             ),
             timeout=_backstop_timeout,
         )
@@ -1593,7 +1622,7 @@ async def main() -> None:
     _prepull_task.add_done_callback(_task_done_callback_main)
 
     # ── 將 GroupQueue 與實際的訊息處理邏輯串接 ──────────────────────────────
-    async def _process_messages_for_jid(jid: str) -> bool:
+    async def _process_messages_for_jid(jid: str, queue_meta: dict) -> bool:
         """
         GroupQueue 的 callback：當輪到某個群組執行時被呼叫。
         從 DB 取得該群組的待處理訊息，執行 container，
@@ -1624,7 +1653,7 @@ async def main() -> None:
                 _last_timestamp = ts
                 db.set_state("lastTimestamp", str(_last_timestamp))
 
-        await _process_group_messages(group, msgs, on_success=advance)
+        await _process_group_messages(group, msgs, on_success=advance, queue_meta=queue_meta)
         # Fix: return actual success/failure so GroupQueue can schedule retries.
         # Previously always returned True, meaning GroupQueue never retried after
         # a container error — the message would only be retried on the next poll


### PR DESCRIPTION
## Linked Issue

Closes #601

## Type of Change

- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Chore / meta** - tooling, CI, docs, or repo housekeeping

## Description

Adds Phase 0 observability on the hot execution path before queue policy or runtime architecture changes.

What changed:
- `host/group_queue.py` now forwards real queue timing metadata (`queued_at_ms`, `started_at_ms`, `queue_wait_ms`) into each run.
- `host/main.py` emits `phase0.message_batch` with request timing, queue timing, prompt length, and message counts.
- `host/container_runner.py` emits `phase0.prompt_metrics`, `phase0.first_progress`, and `phase0.run_complete` so we can measure prompt size, time-to-first-progress, and total response time across success / timeout / error paths.
- `docs/CHANGELOG.md` and `README.md` document the new observability events.

Why:
- Phase 1 work like queue prioritization and prompt slimming needs a baseline.
- Queue wait is now recorded from the real scheduler path instead of inferred later.

## Checklist

- [x] PR body links an issue (or I added the `no-issue` label)
- [x] `docs/CHANGELOG.md` has an entry for this change (or I added the `skip-changelog` label - only valid for non-runtime PRs)
- [x] `README.md` updated if user-visible behavior changed (install steps, env vars, commands, architecture)
- [ ] Tests added or updated where relevant, and `pytest tests/` passes locally

## Verification

- `python -m py_compile host/main.py host/container_runner.py host/group_queue.py`