### PR TITLE
fix(host): Windows self-update restart exits clean for pm2, not os.execv (#605)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.27.41] — 2026-05-19
+
+### Fixed
+- **Self-update restart on Windows no longer uses `os.execv` — exits cleanly for pm2 to respawn.** The `host/main.py` restart block assumed `os.execv` is a true in-place image replacement (same PID), which is the #530 design rationale.  **That holds only on POSIX.** Windows has no real `exec()` syscall — CPython's `os.execv` on Windows is `CreateProcess` + exit, producing a *new* PID and a brief two-process window.  Verified empirically 2026-05-19: parent pid 58992 → execv child pid 107324.  On the Windows host that child races pm2's own `autorestart` respawn and both can try to bind the dashboard / SDK / WS ports (8765 / 8767 / 8768).  Fix: platform-branch the restart — POSIX keeps `os.execv`; Windows does a clean `sys.exit(0)` and lets pm2 `autorestart: true` respawn exactly one process.  The restart flag is already `unlink()`'d at detection so a clean exit cannot loop.
+
+### Technical Details
+- **Modified Files**: `host/main.py` (restart block, platform branch + expanded design comment), `docs/SELF_UPDATE.md` §1 (rewritten as platform-specific).
+- **Image rebuild required**: No (host-side change only — `pm2 restart evoclaw` to apply).
+- **Breaking Changes**: None on POSIX.  On Windows the self-update restart now depends on pm2 (or another supervisor with autorestart); a standalone-launched debug process will exit instead of restarting — acceptable for debugging.
+- **Verification**: empirical `os.execv` PID test on this Windows host (`D:/tmp/execv_pid_test2.py`) confirmed the new-PID behaviour before the fix was written.
+
 ## [1.27.40] — 2026-05-15
 
 ### Added

--- a/docs/SELF_UPDATE.md
+++ b/docs/SELF_UPDATE.md
@@ -4,19 +4,31 @@
 
 本文件集中說明 EvoClaw 如何拉取新程式碼、測試、重啟。原本散在 `host/auto_update.py`、`host/ipc_watcher.py`、`host/main.py` 的 code comment 與多個 CHANGELOG 條目；此文件是單一權威來源。
 
-## 1. 核心設計：os.execv，不是 pm2 restart
+## 1. 核心設計：重啟機制依平台分流
 
-所有自動更新/重啟路徑最終都呼叫 **`os.execv`**（`host/main.py` 結尾），原地替換 process image。
+所有自動更新/重啟路徑最終都進 `host/main.py` 結尾的重啟區塊。重啟機制**依作業系統不同**（Issue #530 + 2026-05-19 Windows 驗證後）：
 
-設計理由（Issue #530，code comment 於 `host/main.py`）：
+### POSIX（Linux / macOS）— `os.execv`
 
-- **os.execv 保 pm2 supervisor PID 穩定** — pm2 看到單一長駐 worker，restart counter 與 uptime 統計合理。
-- **不假設 pm2 在 PATH 上** — EvoClaw 可能直接被啟動 debug，或 pm2 daemon 已 crash。`pm2 restart` 在這些情境會 hang 或失敗，更新卡住。
-- **pm2 `autorestart: true` 仍是 crash safety net** — 若 os.execv 本身失敗或替換後 process 啟動即 crash，pm2 會 respawn。
+真正的原地 image 替換。**同 PID**，pm2 supervisor 看到單一長駐 worker，restart counter / uptime 統計合理。不依賴 pm2 在 PATH 上。
 
-⚠️ 若想「改成 pm2 restart」，先讀 Issue #530 討論。
+### Windows — clean exit，讓 pm2 respawn
 
-`pm2 restart evoclaw`（手動）是**另一回事** — 殺 process 重起、新 PID。只用於手動 host-only 部署，見 §6。
+Windows **沒有真正的 `exec()` syscall**。CPython 在 Windows 上的 `os.execv` = `CreateProcess` + 終止當前 process → **新 PID** + 短暫雙 process 並存視窗。
+
+2026-05-19 實測確認：parent pid 58992 → execv child pid 107324（child ppid=58992）。
+
+該 child 會與 pm2 自己的 `autorestart` respawn **競爭** — 兩個 EvoClaw 實例可能同時搶綁 dashboard / SDK / WS ports（8765 / 8767 / 8768）。所以 Windows 上**不走 execv**：clean `sys.exit(0)`，靠 pm2 `autorestart: true` respawn 恰好一個 process。
+
+若 EvoClaw 是 standalone 啟動 debug（無 pm2），就單純 exit — 可接受，開發者手動重啟。
+
+### 共通
+
+- 重啟 flag 在偵測當下即 `unlink`（`host/main.py:1166` / `:1181`），所以 clean exit 不會造成 restart loop。
+- `pm2 autorestart: true` 是 crash safety net（兩平台皆然）。
+- `restart_notify.json`（#579）是 DATA_DIR 內檔案，跨 exit/respawn 存活，新 process 啟動時讀取 → post-restart 通知兩平台都正常。
+
+⚠️ `pm2 restart evoclaw`（operator 手動下指令）是**另一回事** — 殺 process 重起、新 PID。只用於手動 host-only 部署，見 §7。
 
 ## 2. 四種觸發路徑
 
@@ -86,7 +98,7 @@
 | `<DATA_DIR>/self_update.flag` | 拉 code 後重啟 | `_run_self_update_worktree` / `_inplace` |
 | `<DATA_DIR>/restart.flag` | **不拉 code**，只重啟（reload `.env`、解卡死 channel、套用新 agent image） | `mcp__evoclaw__restart_host` IPC handler |
 
-兩者都被 `host/main.py` 的 main loop 偵測，都設 `_self_update_requested=True`，走同一條 os.execv 路徑 — lifecycle 相同，pm2 看到一個穩定 PID。
+兩者都被 `host/main.py` 的 main loop 偵測，都設 `_self_update_requested=True`，走 §1 的平台分流重啟路徑 — lifecycle 相同。
 
 `<DATA_DIR>/restart_notify.json`（Issue #579）— 在寫 flag 的同時寫入，記 originating chat jid + source label + 起始 timestamp。重啟後 main loop 讀取並 unlink，回送 `✅ EvoClaw 已重啟完成（耗時 Ns）` 給原 chat。Best-effort，失敗不擋重啟。
 

--- a/host/main.py
+++ b/host/main.py
@@ -1953,26 +1953,36 @@ async def main() -> None:
 
     log.info("EvoClaw shut down cleanly.")
 
-    # Self-update: replace current process with a fresh one so updated code is loaded.
+    # Self-update: restart so updated code is loaded.  The restart mechanism
+    # is platform-specific (Issue #530 + Windows follow-up verified 2026-05-19).
     #
-    # Design note (Issue #530): we intentionally use `os.execv` here rather than
-    # shelling out to `pm2 restart evoclaw`.  Rationale:
-    #   * os.execv keeps the pm2 supervisor PID stable — pm2 sees a single
-    #     long-lived worker, not a parent that exited.  Restart counters and
-    #     uptime stats stay sensible.
-    #   * `pm2 restart` would require pm2 to be on PATH and the pm2 daemon to
-    #     be running inside this environment; in edge cases (e.g. pm2 daemon
-    #     crashed, or EvoClaw launched directly for debugging) that call
-    #     would hang or fail and the update would get stuck.
-    #   * pm2's `autorestart: true` is still our crash safety net: if os.execv
-    #     itself fails or the replacement process crashes at startup, pm2
-    #     will respawn us.
-    # If you are tempted to "fix" this by switching to pm2 restart, read the
-    # issue #530 discussion first.
+    # POSIX — os.execv:
+    #   A true in-place image replacement.  Same PID, so the pm2 supervisor
+    #   sees one stable long-lived worker; restart counters / uptime stay
+    #   sensible.  No dependency on pm2 being on PATH.
+    #
+    # Windows — clean exit, let pm2 respawn:
+    #   Windows has no real exec() syscall.  CPython's os.execv on Windows is
+    #   CreateProcess + exit the current process, so it produces a NEW PID and
+    #   a brief window where two processes coexist.  Verified empirically
+    #   2026-05-19: parent pid 58992 → execv child pid 107324 (ppid 58992).
+    #   That child races pm2's own `autorestart` respawn — two EvoClaw
+    #   instances can briefly both try to bind the dashboard / SDK / WS ports
+    #   (8765 / 8767 / 8768).  So on Windows we do NOT execv: we exit cleanly
+    #   and rely on pm2 `autorestart: true` to respawn exactly one process.
+    #   If EvoClaw was launched standalone for debugging (no pm2), it simply
+    #   exits — acceptable, the developer restarts manually.
+    #
+    # The restart flag has already been unlink()'d at detection time, so a
+    # clean exit cannot cause a restart loop.
     if _self_update_requested:
         import sys as _sys_restart
-        log.info("Restarting EvoClaw for self-update via os.execv()...")
-        os.execv(_sys_restart.executable, [_sys_restart.executable] + _sys_restart.argv)
+        if _sys_restart.platform == "win32":
+            log.info("Restarting EvoClaw for self-update via clean exit (Windows; pm2 autorestart respawns)...")
+            _sys_restart.exit(0)
+        else:
+            log.info("Restarting EvoClaw for self-update via os.execv() (POSIX in-place)...")
+            os.execv(_sys_restart.executable, [_sys_restart.executable] + _sys_restart.argv)
 
 
 


### PR DESCRIPTION
## Summary

`host/main.py`'s self-update restart used `os.execv` unconditionally.  The #530 rationale ("os.execv keeps the pm2 PID stable") is **POSIX-only** — Windows has no real `exec()`.

## Evidence

Empirical PID test on the Windows host, 2026-05-19:

```
PARENT pid=58992 ppid=99336
CHILD  pid=107324 ppid=58992
```

`os.execv` on Windows = `CreateProcess` + exit → new PID, brief two-process window.  On the pm2-managed Windows host that child races pm2's `autorestart` respawn and both can try to bind `8765`/`8767`/`8768`.

## Fix

Platform-branch the restart block:

```python
if _self_update_requested:
    import sys as _sys_restart
    if _sys_restart.platform == "win32":
        log.info("Restarting ... via clean exit (Windows; pm2 autorestart respawns)...")
        _sys_restart.exit(0)
    else:
        log.info("Restarting ... via os.execv() (POSIX in-place)...")
        os.execv(_sys_restart.executable, [_sys_restart.executable] + _sys_restart.argv)
```

- **POSIX**: unchanged — true in-place `os.execv`, same PID.
- **Windows**: clean `sys.exit(0)`; pm2 `autorestart: true` respawns exactly one process.
- Restart flag is already `unlink()`'d at detection (`main.py:1166`/`:1181`) → clean exit cannot loop.
- `restart_notify.json` (#579) survives the exit/respawn as a DATA_DIR file → post-restart ack still works.

## Files

| File | Change |
|---|---|
| `host/main.py` | restart block platform branch + expanded design comment |
| `docs/SELF_UPDATE.md` | §1 rewritten as platform-specific |
| `docs/CHANGELOG.md` | entry 1.27.41 |

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` — `host/main.py` syntax OK
- [x] `os.execv` PID behaviour verified empirically on this Windows host before writing the fix
- [ ] Post-merge + `pm2 restart evoclaw`: trigger a real `self_update` (or `/restart`), confirm in `pm2 describe evoclaw` that exactly one process exists after restart and no `address already in use` for 8765/8767/8768 in `pm2-err.log`
- [ ] POSIX path unchanged — no Linux host available this session to re-verify, but the branch leaves the POSIX arm byte-identical to the prior behaviour

## Notes

The POSIX arm is byte-identical to the old code path; only Windows behaviour changes. Branch protection has no required checks; `python-tests` will hang as usual (pre-existing, unrelated).

Closes #605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)