### PR TITLE
fix(host): repair _GroupState field + missing import time (#607)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.27.42] — 2026-05-19
+
+### Fixed
+- **Message loop no longer crashes every poll — `_GroupState` missing field + missing `import time` (#601 regression).** #601 (phase-0 latency instrumentation) introduced two defects in `host/group_queue.py`: (1) it added nine references to `state.pending_message_queued_at_ms` (lines 130/140/148/166/167/405/406/461/462) but never declared the field on the `_GroupState` dataclass; (2) it added seven `int(time.time() * 1000)` calls without adding `import time`. The first `enqueue_message_check()` call raised `AttributeError: '_GroupState' object has no attribute 'pending_message_queued_at_ms'` — and that `AttributeError` at the field-read masked the latent `NameError: name 'time' is not defined` one line below. The host message loop logged `Message loop error: ...` on **every 2 s poll**; the agent processed zero messages — EvoClaw was operationally down. Fix: declare `pending_message_queued_at_ms: Optional[int] = None` on the dataclass **and** add `import time`.
+
+### Technical Details
+- **Modified Files**: `host/group_queue.py` (`import time` added; `_GroupState` dataclass — one field added).
+- **Image rebuild required**: No (host-side change only — `pm2 restart evoclaw` to apply).
+- **Breaking Changes**: None.
+- **Verification**: `enqueue_message_check()` exercised through the `state.active` and `retry_count` branches — both set `pending_message_queued_at_ms` and raise neither `AttributeError` nor `NameError`.
+- Closes #607.
+
 ## [1.27.41] — 2026-05-19
 
 ### Fixed

--- a/host/group_queue.py
+++ b/host/group_queue.py
@@ -9,6 +9,7 @@ over pending messages. Includes exponential backoff retry on failure.
 import asyncio
 import collections
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Callable, Awaitable, Optional, Deque
 
@@ -59,6 +60,7 @@ class _GroupState:
     is_task_container: bool = False # 目前跑的是排程任務（而非訊息回覆）
     running_task_id: Optional[str] = None  # 正在執行的任務 ID（去重複用）
     pending_messages: bool = False  # 是否有訊息等待下一輪處理
+    pending_message_queued_at_ms: Optional[int] = None  # 首個 pending 訊息入列時間（phase-0 latency 觀測，#601）
     pending_tasks: Deque = field(default_factory=collections.deque)  # 等待執行的 _QueuedTask 清單 (O(1) popleft)
     pending_task_ids: set = field(default_factory=set)  # O(1) duplicate check for pending_tasks (issue #446)
     retry_count: int = 0            # 目前連續失敗次數（用於退避計算）


### PR DESCRIPTION
## Problem
`pm2-err.log` emits, every ~2 s:
```
Message loop error: '_GroupState' object has no attribute 'pending_message_queued_at_ms'
```
The host message loop crashes on every poll → **the agent processes zero messages**. EvoClaw is operationally down. P0.

## Root cause
#601 (phase-0 latency instrumentation) introduced **two** defects in `host/group_queue.py`:
1. Added 9 references to `state.pending_message_queued_at_ms` (lines 130/140/148/166/167/405/406/461/462) but never declared the field on the `_GroupState` dataclass.
2. Added 7 `int(time.time() * 1000)` calls but never added `import time`.

The `AttributeError` at the field-read masked the latent `NameError: name 'time' is not defined` one line below — fixing only the dataclass would have surfaced the `NameError` and the loop would still crash.

## Fix
- Declare `pending_message_queued_at_ms: Optional[int] = None` on `_GroupState`.
- Add `import time`.

## Verification
`enqueue_message_check()` exercised through both the `state.active` and `retry_count` branches — both set the field and raise neither `AttributeError` nor `NameError`.

## Deploy
Host-side only — no image rebuild. `pm2 restart evoclaw` to apply.

Closes #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)