### PR TITLE
fix(config): WEBPORTAL_* keys fall back to .env file (#608)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.27.42] — 2026-05-19
+
+### Fixed
+- **Message loop no longer crashes every poll — `_GroupState` missing field + missing `import time` (#601 regression).** #601 (phase-0 latency instrumentation) introduced two defects in `host/group_queue.py`: (1) it added nine references to `state.pending_message_queued_at_ms` (lines 130/140/148/166/167/405/406/461/462) but never declared the field on the `_GroupState` dataclass; (2) it added seven `int(time.time() * 1000)` calls without adding `import time`. The first `enqueue_message_check()` call raised `AttributeError: '_GroupState' object has no attribute 'pending_message_queued_at_ms'` — and that `AttributeError` at the field-read masked the latent `NameError: name 'time' is not defined` one line below. The host message loop logged `Message loop error: ...` on **every 2 s poll**; the agent processed zero messages — EvoClaw was operationally down. Fix: declare `pending_message_queued_at_ms: Optional[int] = None` on the dataclass **and** add `import time`.
+
+### Technical Details
+- **Modified Files**: `host/group_queue.py` (`import time` added; `_GroupState` dataclass — one field added).
+- **Image rebuild required**: No (host-side change only — `pm2 restart evoclaw` to apply).
+- **Breaking Changes**: None.
+- **Verification**: `enqueue_message_check()` exercised through the `state.active` and `retry_count` branches — both set `pending_message_queued_at_ms` and raise neither `AttributeError` nor `NameError`.
+- Closes #607.
+
 ## [1.27.41] — 2026-05-19
 
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.27.43] — 2026-05-19
+
+### Fixed
+- **`WEBPORTAL_ENABLED` now falls back to the `.env` file — the web portal (port 8766) no longer silently fails to start.** `host/config.py` read `WEBPORTAL_ENABLED` (and `WEBPORTAL_PORT` / `WEBPORTAL_HOST`) from `os.environ` only. EvoClaw loads `.env` via `host/env.py:read_env_file()`, which by design **does not pollute `os.environ`**, and `ecosystem.config.js` injects only `PYTHONUNBUFFERED`. So an operator's `WEBPORTAL_ENABLED=true` in `.env` never reached `os.environ`, evaluated to `false`, and `start_webportal()` returned `None` at `webportal.py:477` — port 8766 never bound, with no error logged. The dashboard (8765) was unaffected because `start_dashboard()` has no ENABLED gate. Fix: the three `WEBPORTAL_*` keys now use the same env-var → `.env`-file → default fallback already used by `ENABLED_CHANNELS` and `CONTAINER_MEMORY`.
+
+### Technical Details
+- **Modified Files**: `host/config.py` (`WEBPORTAL_ENABLED` / `WEBPORTAL_PORT` / `WEBPORTAL_HOST` resolution).
+- **Image rebuild required**: No (host-side change only — `pm2 restart evoclaw` to apply).
+- **Breaking Changes**: None. Deployments that set `WEBPORTAL_ENABLED` as a real environment variable are unaffected (env var still takes priority).
+- **Verification**: with `WEBPORTAL_ENABLED=true` in `.env` and no env var set, `host.config.WEBPORTAL_ENABLED` now evaluates `True`.
+- Closes #608.
+
 ## [1.27.42] — 2026-05-19
 
 ### Fixed

--- a/host/config.py
+++ b/host/config.py
@@ -203,9 +203,28 @@ def warn_dashboard_no_password() -> None:
             "Set DASHBOARD_PASSWORD in .env to enable HTTP Basic Auth."
         )
 DASHBOARD_USER = os.environ.get("DASHBOARD_USER", "admin")
-WEBPORTAL_ENABLED = os.environ.get("WEBPORTAL_ENABLED", "false").lower() == "true"
-WEBPORTAL_PORT = _env_int("WEBPORTAL_PORT", 8766)
-WEBPORTAL_HOST = os.environ.get("WEBPORTAL_HOST", "127.0.0.1")
+# Web portal config — env var takes priority; fall back to .env file so
+# operators can set it there (mirrors ENABLED_CHANNELS below).  Reading
+# os.environ alone silently ignored WEBPORTAL_ENABLED=true in .env because
+# read_env_file() deliberately does not pollute os.environ.
+_env_file_webportal = read_env_file(
+    ["WEBPORTAL_ENABLED", "WEBPORTAL_PORT", "WEBPORTAL_HOST"]
+)
+WEBPORTAL_ENABLED = (
+    os.environ.get("WEBPORTAL_ENABLED")
+    or _env_file_webportal.get("WEBPORTAL_ENABLED")
+    or "false"
+).lower() == "true"
+WEBPORTAL_PORT = int(
+    os.environ.get("WEBPORTAL_PORT")
+    or _env_file_webportal.get("WEBPORTAL_PORT")
+    or 8766
+)
+WEBPORTAL_HOST = (
+    os.environ.get("WEBPORTAL_HOST")
+    or _env_file_webportal.get("WEBPORTAL_HOST")
+    or "127.0.0.1"
+)
 HEALTH_PORT = _env_int("HEALTH_PORT", 8769)
 
 # Channels to load (comma-separated, default: telegram)

--- a/host/group_queue.py
+++ b/host/group_queue.py
@@ -9,6 +9,7 @@ over pending messages. Includes exponential backoff retry on failure.
 import asyncio
 import collections
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Callable, Awaitable, Optional, Deque
 
@@ -59,6 +60,7 @@ class _GroupState:
     is_task_container: bool = False # 目前跑的是排程任務（而非訊息回覆）
     running_task_id: Optional[str] = None  # 正在執行的任務 ID（去重複用）
     pending_messages: bool = False  # 是否有訊息等待下一輪處理
+    pending_message_queued_at_ms: Optional[int] = None  # 首個 pending 訊息入列時間（phase-0 latency 觀測，#601）
     pending_tasks: Deque = field(default_factory=collections.deque)  # 等待執行的 _QueuedTask 清單 (O(1) popleft)
     pending_task_ids: set = field(default_factory=set)  # O(1) duplicate check for pending_tasks (issue #446)
     retry_count: int = 0            # 目前連續失敗次數（用於退避計算）


### PR DESCRIPTION
## Problem
Web portal port 8766 is unreachable (connection refused) even though `.env` has `WEBPORTAL_ENABLED=true`. No startup log line, no error — silent.

## Root cause
`host/config.py` read `WEBPORTAL_ENABLED` / `WEBPORTAL_PORT` / `WEBPORTAL_HOST` from `os.environ` only. EvoClaw loads `.env` via `host/env.py:read_env_file()`, whose docstring states it **"does not pollute os.environ"**; `ecosystem.config.js` injects only `PYTHONUNBUFFERED`. So `WEBPORTAL_ENABLED=true` in `.env` never reached `os.environ` → evaluated `false` → `start_webportal()` returned `None` at `webportal.py:477` → 8766 never bound.

Dashboard 8765 was unaffected — `start_dashboard()` has no ENABLED gate.

## Fix
The three `WEBPORTAL_*` keys now use the env-var → `.env`-file → default fallback **already used in the same file** by `ENABLED_CHANNELS` (config.py:211) and `CONTAINER_MEMORY` (config.py:120-125). Env var still takes priority — no behaviour change for env-var deployments.

## Verification
With `WEBPORTAL_ENABLED=true` in `.env` and no env var set, `host.config.WEBPORTAL_ENABLED` now evaluates `True` (was `False`).

## Deploy
Host-side only — no image rebuild. `pm2 restart evoclaw` to apply.

## Note
This branch is **stacked on `fix/groupstate-pending-ts` (#609)** to avoid a CHANGELOG.md merge conflict. Until #609 merges, this PR's diff also shows #609's commit. Merge #609 first; this PR's diff will then reduce to its own commit.

Closes #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)