### PR TITLE
fix(webportal): _watch_stop must not shut down the server on arm failure (#611)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.27.44] — 2026-05-19
+
+### Fixed
+- **Web portal (port 8766) no longer shuts itself down at startup — `_watch_stop` killed the just-started server (#611).** Once #608 let `start_webportal()` actually run, the portal logged `Web portal started at http://127.0.0.1:8766/` but the port never stayed listening, and the log showed `RuntimeWarning: coroutine 'Event.wait' was never awaited`. Cause: `_watch_stop` read the event loop via `stop_event._loop`, but `asyncio.Event._loop` exists yet is `None` until the event is first awaited (Py 3.10+), so the `except AttributeError` fallback to `_captured_loop` never fired. `run_coroutine_threadsafe(stop_event.wait(), None)` raised, the coroutine was never scheduled (hence the warning), `except Exception: pass` swallowed it, and execution **fell through to `server.shutdown()`** — stopping the server milliseconds after `t.start()`. `start_dashboard()` has the same `_loop` flaw but calls `run_coroutine_threadsafe` *outside* its `try`, so the exception kills the watcher thread before `server.shutdown()` is reached — which is why dashboard 8765 survived and webportal 8766 did not. Fix: resolve the loop as `getattr(stop_event, "_loop", None) or _captured_loop`, and `return` (leaving the server running) instead of falling through to `server.shutdown()` when the watcher cannot arm.
+
+### Technical Details
+- **Modified Files**: `host/webportal.py` (`_watch_stop` — loop resolution + no shutdown-on-failure).
+- **Image rebuild required**: No (host-side change only — `pm2 restart evoclaw` to apply).
+- **Breaking Changes**: None.
+- **Verification**: after `pm2 restart evoclaw`, port 8766 stays in `LISTEN` state and serves HTTP.
+- **Known related**: `start_dashboard()` carries the same `stop_event._loop`-is-`None` flaw; its watcher is effectively a no-op (cannot arm) but does not kill the dashboard. Out of scope for #611 — tracked separately if graceful dashboard shutdown is needed.
+- Closes #611.
+
 ## [1.27.43] — 2026-05-19
 
 ### Fixed

--- a/host/webportal.py
+++ b/host/webportal.py
@@ -508,15 +508,23 @@ def start_webportal(stop_event=None):
         _captured_loop = _asyncio.get_running_loop()
 
         def _watch_stop():
-            try:
-                loop = stop_event._loop  # type: ignore[attr-defined]
-            except AttributeError:
-                loop = _captured_loop
+            # asyncio.Event._loop exists but is None until the event is first
+            # awaited (Py 3.10+), so `stop_event._loop` alone yields None and
+            # never triggers the AttributeError fallback.  Use the loop captured
+            # at call time as the reliable source.  (#611)
+            loop = getattr(stop_event, "_loop", None) or _captured_loop
             try:
                 future = _asyncio.run_coroutine_threadsafe(stop_event.wait(), loop)
-                future.result()
+                future.result()  # blocks until stop_event.set()
             except Exception:
-                pass
+                # The watcher could not arm itself.  Do NOT fall through to
+                # server.shutdown() — that would kill a server that was never
+                # asked to stop (the #611 bug).  Leave the server running.
+                log.exception(
+                    "WebPortal: stop-event watcher failed to arm; "
+                    "server will keep running and will not auto-shutdown"
+                )
+                return
             server.shutdown()
 
         watcher = threading.Thread(target=_watch_stop, daemon=True, name="webportal-stopper")


### PR DESCRIPTION
## Problem
After #608 fixed the `WEBPORTAL_ENABLED` gate, `start_webportal()` runs and logs `Web portal started at http://127.0.0.1:8766/` — but port 8766 never stays listening. Log shows `RuntimeWarning: coroutine 'Event.wait' was never awaited`. Dashboard 8765 (same process) is unaffected.

## Root cause
`_watch_stop` in `host/webportal.py`:
```python
try:
    loop = stop_event._loop          # asyncio.Event._loop EXISTS but is None until first await (Py 3.10+)
except AttributeError:
    loop = _captured_loop             # never reached — attr exists, just None
try:
    future = _asyncio.run_coroutine_threadsafe(stop_event.wait(), loop)  # loop=None -> raises
    future.result()
except Exception:
    pass                              # swallows it
server.shutdown()                     # <-- runs unconditionally -> kills the just-started server
```
`run_coroutine_threadsafe(coro, None)` raises, the coroutine is never scheduled (the RuntimeWarning), the bare `except` swallows the failure, and execution falls through to `server.shutdown()` milliseconds after `t.start()`.

`start_dashboard()` has the same `_loop` flaw but calls `run_coroutine_threadsafe` **outside** its `try`, so the exception kills the watcher thread before `server.shutdown()` is reached — which is why 8765 survives and 8766 dies.

## Fix
- Resolve the loop robustly: `loop = getattr(stop_event, "_loop", None) or _captured_loop`.
- `return` (leave the server running) instead of falling through to `server.shutdown()` when the watcher cannot arm.

## Verification
Post-deploy: after `pm2 restart evoclaw`, port 8766 stays in `LISTEN` state and serves HTTP.

## Deploy
Host-side only — no image rebuild. `pm2 restart evoclaw` to apply.

## Note
`start_dashboard()` carries the same latent `stop_event._loop`-is-`None` flaw — its watcher cannot arm either, but it does not kill the dashboard. Out of scope here; tracked in the CHANGELOG note if graceful dashboard shutdown is later needed.

Closes #611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)