### PR TITLE
fix(agent): break Gemini loop on duplicate completion-confirmation send_message (#613)

### DIFF
--- a/container/agent-runner/_loop_gemini.py
+++ b/container/agent-runner/_loop_gemini.py
@@ -77,6 +77,7 @@ def run_agent(client_holder, system_instruction: str, user_message: str, chat_ji
     _turns_since_notify = 0   # turns since last mcp__evoclaw__send_message call
     _only_notify_turns = 0    # consecutive turns with ONLY send_message (no real work)
     _no_tool_turns = 0        # consecutive turns without any tool call
+    _completion_send_count = 0  # # of send_message calls whose text matched completion-confirmation phrases (#613)
     # Tools that represent actual work (not just reporting)
     _SUBSTANTIVE_TOOLS_GEMINI = frozenset([
         "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch",
@@ -96,6 +97,19 @@ def run_agent(client_holder, system_instruction: str, user_message: str, chat_ji
         r'|(?:Task\s+(?:is\s+)?(?:complete|done|finished))'            # Task complete
         r'|(?:Successfully\s+(?:completed|executed|ran|written))',      # Successfully executed
         _re_gemini.DOTALL | _re_gemini.IGNORECASE,
+    )
+    # #613: completion-confirmation phrases sent via send_message. The agent must
+    # not deliver more than ONE such confirmation per run. The second match within
+    # a single run triggers a hard break to prevent the "✅已完成 / 任務完成 /
+    # 所有任務已完成 / ✅已完成 / 任務完成 ..." duplicate-spam pattern.
+    _COMPLETION_PHRASE_RE_G = _re_gemini.compile(
+        r'(?:✅\s*已完成'
+        r'|✅\s*完成'
+        r'|所有任務(?:都)?(?:已)?完成'
+        r'|任務完成'
+        r'|task\s+(?:is\s+)?(?:complete|done|finished)'
+        r'|all\s+tasks?\s+(?:are\s+)?(?:complete|done|finished))',
+        _re_gemini.IGNORECASE,
     )
 
     # P16B-FIX-7: cache GEMINI_MODEL once before the loop rather than re-reading
@@ -241,6 +255,17 @@ def run_agent(client_holder, system_instruction: str, user_message: str, chat_ji
                 if "MEMORY.md" in _fc_args_str or _memory_path_str in _fc_args_str:
                     _memory_written = True
                     _log("🧠 MEMORY-WRITE", f"Gemini updated MEMORY.md via {fc.name} on turn {n}")
+            # #613: count completion-confirmation send_message calls. Multiple
+            # confirmations per run are spam (e.g. "✅已完成" then "任務完成"
+            # then "所有任務已完成"). Tracked regardless of whether other tools
+            # ran this turn — _only_notify_turns above resets on interleaved
+            # real work and so misses this pattern entirely.
+            if fc.name == "mcp__evoclaw__send_message":
+                _send_args_dict = dict(fc.args) if fc.args else {}
+                _send_text = str(_send_args_dict.get("text") or _send_args_dict.get("message") or "")
+                if _COMPLETION_PHRASE_RE_G.search(_send_text):
+                    _completion_send_count += 1
+                    _log("⚠️ COMPLETION-SEND", f"Gemini sent completion-confirmation #{_completion_send_count} on turn {n}: {_send_text[:80]!r}")
             # 將工具結果包裝成 FunctionResponse 格式，Gemini 要求此格式
             fn_responses.append(
                 types.Part(function_response=types.FunctionResponse(
@@ -358,6 +383,16 @@ def run_agent(client_holder, system_instruction: str, user_message: str, chat_ji
                         continue
                 break
             history = _keep_fewshot + history[_tail_start:]
+
+        # #613: hard break on duplicate completion-confirmation sends. The first
+        # confirmation is the legitimate "task done" message; a second is spam
+        # ("✅已完成" then "任務完成" then "所有任務已完成" loop). Soft warnings
+        # (FAKE-PROGRESS / MILESTONE) failed to stop this in practice because
+        # interleaved real work resets _only_notify_turns. Break the loop now
+        # rather than waiting for MAX_ITER to cap the bleeding.
+        if _completion_send_count >= 2:
+            _log("🚨 COMPLETION-LOOP", f"Gemini emitted {_completion_send_count} completion-confirmation send_message calls in this run — breaking to prevent duplicate spam")
+            break
 
     if not final_response:
         _log("⚠️ LOOP-EXHAUST", f"Gemini agent loop hit MAX_ITER={MAX_ITER} without text response — no final text collected")

--- a/container/agent-runner/soul.md
+++ b/container/agent-runner/soul.md
@@ -118,6 +118,19 @@ When the user asks for analysis of a GitHub repo or any project you have local a
   - *"`path/to/file.py:N` implements X via the `foo()` function (verified)"*.
 - **The EvoClaw repo specifically.** The agent runs **inside** this codebase.  When asked about EvoClaw, read `CLAUDE.md`, `host/main.py`, and `container/agent-runner/agent.py` before describing the system.  Do not regurgitate README bullets you have not verified.
 
+### 結果只送一次 (No Duplicate Completion Messages) (#613)
+
+After you have delivered the result of a task via `mcp__evoclaw__send_message`, **end your turn**. Do NOT send additional confirmation messages like:
+
+- ❌ `所有任務已完成：...`
+- ❌ `任務完成：...`
+- ❌ `✅ 已完成：...` (when you already sent one this run)
+- ❌ `Task complete.` / `All tasks done.` (when you already sent one this run)
+
+One result message per run. The host already knows the run finished — it sees your loop terminate. Sending "I am now finished" two or three times is pure spam and triggers the `🚨 COMPLETION-LOOP` hard break (`_loop_gemini.py` #613).
+
+If you legitimately have more substantive output to send (e.g. a follow-up file, a separate piece of data), prefix it with the content, not with another "已完成" header. The first completion confirmation is your **only** completion confirmation.
+
 ### MEMORY.md edits: bounded loop, no internal narration (#586)
 
 When updating `MEMORY.md`:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.27.45] — 2026-05-20
+
+### Fixed
+- **Gemini agent no longer spam-repeats completion-confirmation messages within a single run (#613).** In `telegram_8259652816` on 2026-05-19 the agent sent 7 bot messages within one container run, most being redundant `✅ 已完成 / 任務完成 / 所有任務已完成` narration. `pm2-err.log` confirmed a single `Processing 1 message(s)` dispatch — the loop was internal, not host re-dispatch (`host/db.py:579` `get_new_messages` correctly filters `is_bot_message=0`). The existing `_only_notify_turns` guard in `_loop_gemini.py` did not catch it because the agent **interleaved** real `Read`/`Write` work between the duplicate completion messages, resetting the counter each time. Fix in two parts: (1) `soul.md` now contains an explicit "結果只送一次" rule under 誠實性規則, listing the forbidden duplicate-confirmation patterns; (2) `_loop_gemini.py` counts every `send_message` whose text matches a completion-phrase regex (`✅ 已完成`, `任務完成`, `所有任務已完成`, `task complete`, `all tasks done`, …) — when the count reaches 2 the iteration loop hard-breaks via `🚨 COMPLETION-LOOP`, capping user-visible damage to at most one duplicate regardless of whether the model obeys the prompt rule.
+
+### Technical Details
+- **Modified Files**: `container/agent-runner/_loop_gemini.py` (new `_COMPLETION_PHRASE_RE_G` regex, `_completion_send_count` tracker, per-fc detection, end-of-iteration hard break); `container/agent-runner/soul.md` (new "結果只送一次" section under 誠實性規則).
+- **Image rebuild required**: **Yes** — `docker build -t evoclaw-agent:latest container/` before `pm2 restart evoclaw` (per `reference_deploy_flow.md`).
+- **Breaking Changes**: None. A run that legitimately needs more than one `已完成` confirmation (extremely rare) will hit the hard break — but such a pattern is the spam signature this fix targets.
+- **Verification**: regex smoke-tested against the 7 observed messages — first informational `📄 已讀取` does not match, completion-confirmation messages #2 and #3 do match → loop would have broken after 2 sends instead of 7.
+- **Known related**: `_loop_openai.py` and `_loop_claude.py` have the same structural flaw. Production runs Gemini, so this PR fixes only `_loop_gemini.py`; OpenAI/Claude tracked as follow-up.
+- Closes #613.
+
 ## [1.27.44] — 2026-05-19
 
 ### Fixed


### PR DESCRIPTION
Closes #613.

## Symptom

Agent in `telegram_8259652816` sent **7 bot messages within one container run** on 2026-05-19, most being redundant `✅ 已完成 / 任務完成 / 所有任務已完成` narration.

## Diagnosis (verified)

- `pm2-err.log`: `Processing 1 message(s) for telegram_8259652816` appears only **once** at 19:51:24 → single container run, not host re-dispatch.
- `host/db.py:579` `get_new_messages` filters `is_bot_message = 0` → bot messages cannot retrigger the host loop. Host path is correct.
- The loop is internal to `_loop_gemini.py`.

The existing `_only_notify_turns` guard fails here because the agent **interleaved** real `Read` / `Write` work between the duplicate completion messages, resetting the streak counter each turn. Soft warnings (FAKE-PROGRESS / MILESTONE) eventually fired but the model ignored them until `MAX_ITER`.

## Fix (two parts)

1. **Prompt rule** — `container/agent-runner/soul.md` new section `### 結果只送一次 (No Duplicate Completion Messages) (#613)` under 誠實性規則. Lists the forbidden duplicate patterns and notes the enforcer.

2. **Hard break** — `container/agent-runner/_loop_gemini.py`:
   - new `_COMPLETION_PHRASE_RE_G` regex covering `✅ 已完成`, `任務完成`, `所有任務(都)?已完成`, `task complete`, `all tasks done`, etc.
   - new `_completion_send_count` tracker
   - per-fc detection inside the function-call loop: when `fc.name == "mcp__evoclaw__send_message"` and the text arg matches the regex, increment
   - end-of-iteration check: when `_completion_send_count >= 2`, log `🚨 COMPLETION-LOOP` and `break` rather than waiting for `MAX_ITER`

This caps user-visible damage to **one** duplicate at most, regardless of whether the model obeys the prompt rule.

## Verification

Regex smoke-tested locally against the 7 observed messages:

| # | Message (excerpt) | Match? |
|---|---|---|
| 1 | `📄 已讀取 MEMORY.md 並準備傳送架構圖檔案。` | no — informational, not "completion" |
| 2 | `✅ 已完成：架構圖已產生並傳送。MEMORY.md 已更新。` | **yes** (count=1) |
| 3 | `所有任務已完成：架構圖已產生並傳送，MEMORY.md 已更新。` | **yes** (count=2 → BREAK) |
| 4–7 | `✅ 已更新 ...`, `所有任務已完成 ...`, `✅ 已完成 ...`, `任務完成 ...` | would never have been sent |

`miss1` / `miss2` (normal user-facing reply with no completion phrase) do not match → no false positive.

## Deploy

- **Image rebuild required**: `docker build -t evoclaw-agent:latest container/`
- Then `pm2 restart evoclaw`
- Per `reference_deploy_flow.md` memory.

## Scope notes

- `_loop_openai.py` and `_loop_claude.py` have the same structural flaw. Production runs Gemini, so this PR fixes only the Gemini loop to keep the change small. Follow-up issue will port the fix.
- CHANGELOG entry: `1.27.45 — 2026-05-20`.