### PR TITLE
docs: require issue-first GitHub workflow (#615)

### DIFF
--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -223,8 +223,26 @@ git switch -c <topic-branch>
 git push -u origin <topic-branch>
 ```
 
+Default rule:
+
+- open or confirm the tracking issue before pushing work through the normal GitHub flow
+- do not push feature or documentation work directly to `main`
+- the normal path is `topic branch -> PR -> merge -> sync local main`
+- direct `push origin main` should be treated as an exception, not the default workflow
+
+Recommended order:
+
+1. issue
+2. topic branch
+3. local implementation and verification
+4. push branch
+5. PR linked to the issue
+6. merge
+7. sync local `main`
+
 Remote expectations:
 
+- the PR should have a real issue behind it unless the change is genuinely trivial
 - the PR should link its issue
 - the PR should describe verification actually performed
 - the PR should call out whether `container/` changed


### PR DESCRIPTION
## Linked Issue

Closes #615

## Type of Change

- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [x] **Chore / meta** - tooling, CI, docs, or repo housekeeping

## Description

Clarifies the GitHub workflow section in `docs/DEVELOPMENT_WORKFLOW.md` so the default remote flow is explicitly issue-first.

What changed:
- states that the normal remote path must start by opening or confirming the tracking issue
- states that direct `push origin main` is exception-only, not the default workflow
- adds an explicit recommended order: `issue -> topic branch -> local verify -> push -> PR -> merge -> sync main`

## Checklist

- [x] PR body links an issue (or I added the `no-issue` label)
- [ ] `docs/CHANGELOG.md` has an entry for this change (or I added the `skip-changelog` label - only valid for non-runtime PRs)
- [ ] `README.md` updated if user-visible behavior changed (install steps, env vars, commands, architecture)
- [ ] Tests added or updated where relevant, and `pytest tests/` passes locally

## Verification

- docs review only; no code or runtime behavior changed